### PR TITLE
Add the do-exclusively script to the images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN set -ex && cd ~ \
   && [ $(sha256sum shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz | cut -f1 -d' ') = ${SHELLCHECK_SHA256SUM} ] \
   && tar xvfa shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz \
   && mv shellcheck-v${SHELLCHECK_VERSION}/shellcheck /usr/local/bin \
+  && chown root:root /usr/local/bin/shellcheck \
   && rm -vrf shellcheck-v${SHELLCHECK_VERSION} shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz
 
 # install circleci cli
@@ -22,6 +23,7 @@ RUN set -ex && cd ~ \
   && tar xzf circleci-cli_${CIRCLECI_CLI_VERSION}_linux_amd64.tar.gz \
   && mv circleci-cli_${CIRCLECI_CLI_VERSION}_linux_amd64/circleci /usr/local/bin \
   && chmod 755 /usr/local/bin/circleci \
+  && chown root:root /usr/local/bin/circleci \
   && rm -vrf circleci-cli_${CIRCLECI_CLI_VERSION}_linux_amd64 circleci-cli_${CIRCLECI_CLI_VERSION}_linux_amd64.tar.gz
 
 # install awscliv2, disable default pager (less)
@@ -43,8 +45,13 @@ ARG CHAMBER_SHA256SUM=4a47bd9f7fb46ba4a3871efbb60931592defe7c954bd10b4e92323aa30
 RUN set -ex && cd ~ \
   && curl -sSLO https://github.com/segmentio/chamber/releases/download/v${CHAMBER_VERSION}/chamber-v${CHAMBER_VERSION}-linux-amd64 \
   && [ $(sha256sum chamber-v${CHAMBER_VERSION}-linux-amd64 | cut -f1 -d' ') = ${CHAMBER_SHA256SUM} ] \
-  && chmod 755 chamber-v${CHAMBER_VERSION}-linux-amd64 \
-  && mv chamber-v${CHAMBER_VERSION}-linux-amd64 /usr/local/bin/chamber
+  && mv chamber-v${CHAMBER_VERSION}-linux-amd64 /usr/local/bin/chamber \
+  && chmod 755 /usr/local/bin/chamber
+
+# Install scripts
+COPY scripts/do-exclusively /usr/local/bin/do-exclusively
+RUN chmod 755 /usr/local/bin/do-exclusively \
+  && chown root:root /usr/local/bin/do-exclusively
 
 # install pip packages
 ARG CACHE_PIP

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,11 @@
+# Scripts
+
+Scripts in this directory are added to the primary Dockerfile image at `/usr/local/bin`.
+
+## CircleCI Scripts
+
+These scripts are primarily used for CircleCI workflows.
+
+| Script Name | Description |
+| --- | --- |
+| `do-exclusively` | CircleCI's current recommendation for roughly serializing a subset of build commands for a given branch |

--- a/scripts/do-exclusively
+++ b/scripts/do-exclusively
@@ -1,0 +1,104 @@
+#! /usr/bin/env bash
+
+########################################################################################
+# CircleCI's current recommendation for roughly serializing a subset
+# of build commands for a given branch
+#
+# circle discussion thread - https://discuss.circleci.com/t/serializing-deployments/153
+# Code from - https://github.com/bellkev/circle-lock-test
+#
+# Modified by https://github.com/transcom/mymove/commit/f937120716c6a00d847277e5f397fce7c8e214c6
+# to include job-name flag
+########################################################################################
+
+
+# sets $branch, $job_name, $tag, $rest
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            -b|--branch) branch="$2" ;;
+            -j|--job-name) job_name="$2" ;;
+            -t|--tag) tag="$2" ;;
+            *) break ;;
+        esac
+        shift 2
+    done
+    rest=("$@")
+}
+
+# reads $branch, $tag, $commit_message
+should_skip() {
+    if [[ "$branch" && "$CIRCLE_BRANCH" != "$branch" ]]; then
+        echo "Not on branch $branch. Skipping..."
+        return 0
+    fi
+
+    if [[ "$job_name" && "$CIRCLE_JOB" != "$job_name" ]]; then
+        echo "Not running $job_name. Skipping..."
+        return 0
+    fi
+
+    if [[ "$tag" && "$commit_message" != *\[$tag\]* ]]; then
+        echo "No [$tag] commit tag found. Skipping..."
+        return 0
+    fi
+
+    return 1
+}
+
+# reads $branch, $job_name, $tag
+# sets $jq_prog
+make_jq_prog() {
+    local jq_filters=""
+
+    if [[ $branch ]]; then
+        jq_filters+=" and .branch == \"$branch\""
+    fi
+
+    if [[ $job_name ]]; then
+        jq_filters+=" and .workflows?.job_name? == \"$job_name\""
+    fi
+
+    if [[ $tag ]]; then
+        jq_filters+=" and (.subject | contains(\"[$tag]\"))"
+    fi
+
+    jq_prog=".[] | select(.build_num < $CIRCLE_BUILD_NUM and (.status | test(\"running|pending|queued\")) $jq_filters) | .build_num"
+}
+
+
+if [[ "$0" != *bats* ]]; then
+set -e
+set -u
+set -o pipefail
+
+    branch=""
+    tag=""
+    rest=()
+    api_url="https://circleci.com/api/v1/project/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME?circle-token=$CIRCLE_TOKEN&limit=100"
+
+    parse_args "$@"
+    commit_message=$(git log -1 --pretty=%B)
+    if should_skip; then exit 0; fi
+    make_jq_prog
+
+    echo "Checking for running builds..."
+
+    while true; do
+        builds=$(curl -s -H "Accept: application/json" "$api_url" | jq "$jq_prog")
+        if [[ $builds ]]; then
+            echo "Waiting on builds:"
+            echo "$builds"
+        else
+            break
+        fi
+        echo "Retrying in 10 seconds..."
+        sleep 10
+    done
+
+    echo "Acquired lock"
+
+    if [[ "${#rest[@]}" -ne 0 ]]; then
+        "${rest[@]}"
+    fi
+fi


### PR DESCRIPTION
This script is pretty integral to doing work on circleci and should be in the base image since almost all builds will need it. It also means I won't need to copy it from the mymove repo to the milmove_orders repo just to use it. 

I've also fixed some script ownership issues I found while investigating this ticket.