### PR TITLE
Add milmove-app-browsers Dockerfile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,8 +7,8 @@ jobs:
       - run:
           name: Check for reserved branch names
           command: |
-            if [[ $CIRCLE_BRANCH = latest || $CIRCLE_BRANCH = milmove-app || $CIRCLE_BRANCH = milmove-infra || $CIRCLE_BRANCH = milmove-orders ]]; then
-              echo "Don't use a branch named 'latest', 'milmove-app', 'milmove-infra', 'milmove-orders'; these are meaningful tags."
+            if [[ $CIRCLE_BRANCH = latest || $CIRCLE_BRANCH = milmove-app || $CIRCLE_BRANCH = milmove-app-browsers || $CIRCLE_BRANCH = milmove-infra || $CIRCLE_BRANCH = milmove-orders ]]; then
+              echo "Don't use a branch named 'latest', 'milmove-app', 'milmove-app-browsers', 'milmove-infra', 'milmove-orders'; these are meaningful tags."
               exit 1
             fi
       - run:
@@ -36,6 +36,10 @@ jobs:
               docker tag  milmove/circleci-docker:milmove-app milmove/circleci-docker:milmove-app-$tag
               docker push milmove/circleci-docker:milmove-app-$tag
 
+              # milmove-app-browsers
+              docker tag  milmove/circleci-docker:milmove-app-browsers milmove/circleci-docker:milmove-app-browsers-$tag
+              docker push milmove/circleci-docker:milmove-app-browsers-$tag
+
               # milmove-infra
               docker tag  milmove/circleci-docker:milmove-infra milmove/circleci-docker:milmove-infra-$tag
               docker push milmove/circleci-docker:milmove-infra-$tag
@@ -49,6 +53,7 @@ jobs:
             if [[ $CIRCLE_BRANCH = master ]]; then
               docker push milmove/circleci-docker
               docker push milmove/circleci-docker:milmove-app
+              docker push milmove/circleci-docker:milmove-app-browsers
               docker push milmove/circleci-docker:milmove-infra
               docker push milmove/circleci-docker:milmove-orders
             fi

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ For the latest stable images:
 * `milmove/circleci-docker:latest`
 * `milmove/circleci-docker:base`
 * `milmove/circleci-docker:milmove-app`
+* `milmove/circleci-docker:milmove-app-browsers`
 * `milmove/circleci-docker:milmove-infra`
 * `milmove/circleci-docker:milmove-orders`
 
@@ -50,6 +51,12 @@ In addition to the Base Image this contains:
   * [Yarn](https://yarnpkg.com/)
   * postgresql-client
   * entr
+
+### MilMove App Browsers
+
+In addition to the MilMove App Image this contains:
+
+* [Chrome](https://www.google.com/chrome/)
 
 ### MilMove Infra
 

--- a/build
+++ b/build
@@ -25,6 +25,13 @@ docker build --build-arg CACHE_APT="$CACHE_APT" \
              .
 popd
 
+pushd milmove-app-browsers
+docker build --build-arg CACHE_APT="$CACHE_APT" \
+             --build-arg CACHE_PIP="$CACHE_PIP" \
+             -t milmove/circleci-docker:milmove-app-browsers \
+             .
+popd
+
 pushd milmove-infra
 docker build -t milmove/circleci-docker:milmove-infra \
              .

--- a/milmove-app-browsers/Dockerfile
+++ b/milmove-app-browsers/Dockerfile
@@ -1,0 +1,70 @@
+# CircleCI docker image to run within
+FROM milmove/circleci-docker:milmove-app
+
+# Base image uses "circleci", to avoid using `sudo` run as root user
+USER root
+
+# apt-get project dependencies
+# Notes:
+# - When adding apt sources do it before 'apt-get update'
+ARG CACHE_APT
+RUN set -ex && cd ~ \
+  && : Install chrome deps via apt packages \
+  && apt-get -qq update \
+  && apt-get -qq -y install --no-install-recommends \
+    fonts-liberation \
+    libappindicator3-1 \
+    libasound2 \
+    libatk-bridge2.0-0 \
+    libatk1.0-0 \
+    libatspi2.0-0 \
+    libcups2 \
+    libdbus-1-3 \
+    libgtk-3-0 \
+    libnspr4 \
+    libnss3 \
+    libxcomposite1 \
+    libxcursor1 \
+    libxi6 \
+    libxrandr2 \
+    libxtst6 \
+    xdg-utils \
+  && : Cleanup \
+  && apt-get clean \
+  && rm -vrf /var/lib/apt/lists/*
+
+# install chrome
+
+RUN curl --silent --show-error --location --fail --retry 3 --output /tmp/google-chrome-stable_current_amd64.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb \
+    && (sudo dpkg -i /tmp/google-chrome-stable_current_amd64.deb || sudo apt-get -fy install)  \
+    && rm -rf /tmp/google-chrome-stable_current_amd64.deb \
+    && sudo sed -i 's|HERE/chrome"|HERE/chrome" --disable-setuid-sandbox --no-sandbox|g' \
+        "/opt/google/chrome/google-chrome" \
+    && google-chrome --version
+
+RUN CHROME_VERSION="$(google-chrome --version)" \
+    && export CHROMEDRIVER_RELEASE="$(echo $CHROME_VERSION | sed 's/^Google Chrome //')" && export CHROMEDRIVER_RELEASE=${CHROMEDRIVER_RELEASE%%.*} \
+    && CHROMEDRIVER_VERSION=$(curl --silent --show-error --location --fail --retry 4 --retry-delay 5 http://chromedriver.storage.googleapis.com/LATEST_RELEASE_${CHROMEDRIVER_RELEASE}) \
+    && curl --silent --show-error --location --fail --retry 4 --retry-delay 5 --output /tmp/chromedriver_linux64.zip "http://chromedriver.storage.googleapis.com/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip" \
+    && cd /tmp \
+    && unzip chromedriver_linux64.zip \
+    && rm -rf chromedriver_linux64.zip \
+    && sudo mv chromedriver /usr/local/bin/chromedriver \
+    && sudo chmod +x /usr/local/bin/chromedriver \
+    && chromedriver --version
+
+# start xvfb automatically to avoid needing to express in circle.yml
+ENV DISPLAY :99
+RUN printf '#!/bin/sh\nXvfb :99 -screen 0 1280x1024x24 &\nexec "$@"\n' > /tmp/entrypoint \
+  && chmod +x /tmp/entrypoint \
+        && sudo mv /tmp/entrypoint /docker-entrypoint.sh
+
+#ENV CHROME_PATH=/opt/google/chrome
+
+# ensure that the build agent doesn't override the entrypoint
+LABEL com.circleci.preserve-entrypoint=true
+
+USER circleci
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["/bin/sh"]

--- a/milmove-app-browsers/Dockerfile
+++ b/milmove-app-browsers/Dockerfile
@@ -36,28 +36,28 @@ RUN set -ex && cd ~ \
 # install chrome
 
 RUN curl --silent --show-error --location --fail --retry 3 --output /tmp/google-chrome-stable_current_amd64.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb \
-    && (sudo dpkg -i /tmp/google-chrome-stable_current_amd64.deb || sudo apt-get -fy install)  \
-    && rm -rf /tmp/google-chrome-stable_current_amd64.deb \
-    && sudo sed -i 's|HERE/chrome"|HERE/chrome" --disable-setuid-sandbox --no-sandbox|g' \
-        "/opt/google/chrome/google-chrome" \
-    && google-chrome --version
+  && (sudo dpkg -i /tmp/google-chrome-stable_current_amd64.deb || sudo apt-get -fy install)  \
+  && rm -rf /tmp/google-chrome-stable_current_amd64.deb \
+  && sudo sed -i 's|HERE/chrome"|HERE/chrome" --disable-setuid-sandbox --no-sandbox|g' \
+    "/opt/google/chrome/google-chrome" \
+  && google-chrome --version
 
 RUN CHROME_VERSION="$(google-chrome --version)" \
-    && export CHROMEDRIVER_RELEASE="$(echo $CHROME_VERSION | sed 's/^Google Chrome //')" && export CHROMEDRIVER_RELEASE=${CHROMEDRIVER_RELEASE%%.*} \
-    && CHROMEDRIVER_VERSION=$(curl --silent --show-error --location --fail --retry 4 --retry-delay 5 http://chromedriver.storage.googleapis.com/LATEST_RELEASE_${CHROMEDRIVER_RELEASE}) \
-    && curl --silent --show-error --location --fail --retry 4 --retry-delay 5 --output /tmp/chromedriver_linux64.zip "http://chromedriver.storage.googleapis.com/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip" \
-    && cd /tmp \
-    && unzip chromedriver_linux64.zip \
-    && rm -rf chromedriver_linux64.zip \
-    && sudo mv chromedriver /usr/local/bin/chromedriver \
-    && sudo chmod +x /usr/local/bin/chromedriver \
-    && chromedriver --version
+  && export CHROMEDRIVER_RELEASE="$(echo $CHROME_VERSION | sed 's/^Google Chrome //')" && export CHROMEDRIVER_RELEASE=${CHROMEDRIVER_RELEASE%%.*} \
+  && CHROMEDRIVER_VERSION=$(curl --silent --show-error --location --fail --retry 4 --retry-delay 5 http://chromedriver.storage.googleapis.com/LATEST_RELEASE_${CHROMEDRIVER_RELEASE}) \
+  && curl --silent --show-error --location --fail --retry 4 --retry-delay 5 --output /tmp/chromedriver_linux64.zip "http://chromedriver.storage.googleapis.com/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip" \
+  && cd /tmp \
+  && unzip chromedriver_linux64.zip \
+  && rm -rf chromedriver_linux64.zip \
+  && sudo mv chromedriver /usr/local/bin/chromedriver \
+  && sudo chmod +x /usr/local/bin/chromedriver \
+  && chromedriver --version
 
 # start xvfb automatically to avoid needing to express in circle.yml
 ENV DISPLAY :99
 RUN printf '#!/bin/sh\nXvfb :99 -screen 0 1280x1024x24 &\nexec "$@"\n' > /tmp/entrypoint \
   && chmod +x /tmp/entrypoint \
-        && sudo mv /tmp/entrypoint /docker-entrypoint.sh
+  && sudo mv /tmp/entrypoint /docker-entrypoint.sh
 
 #ENV CHROME_PATH=/opt/google/chrome
 

--- a/test
+++ b/test
@@ -66,7 +66,7 @@ function test_milmove_orders() {
   echo "Passed ${tag}"
 }
 
-for tag in latest milmove-app milmove-infra milmove-orders; do
+for tag in latest milmove-app milmove-app-browsers milmove-infra milmove-orders; do
   echo
   echo "* Testing USER is properly set to 'circleci' on '${tag}' tagged image"
   docker run -it "milmove/circleci-docker:${tag}" bash -xc '[[ $(whoami) = circleci ]]'

--- a/test
+++ b/test
@@ -38,9 +38,8 @@ function test_milmove_app_browsers() {
   tag=milmove-app-browsers
   echo "Testing ${tag} Dockerfile"
 
-  docker run -it "milmove/circleci-docker:${tag}" node --version
-  docker run -it "milmove/circleci-docker:${tag}" yarn --version
   docker run -it "milmove/circleci-docker:${tag}" google-chrome --version
+  docker run -it "milmove/circleci-docker:${tag}" chromedriver --version
 
   echo "Passed ${tag}"
 }

--- a/test
+++ b/test
@@ -34,6 +34,17 @@ function test_milmove_app() {
   echo "Passed ${tag}"
 }
 
+function test_milmove_app_browsers() {
+  tag=milmove-app-browsers
+  echo "Testing ${tag} Dockerfile"
+
+  docker run -it "milmove/circleci-docker:${tag}" node --version
+  docker run -it "milmove/circleci-docker:${tag}" yarn --version
+  docker run -it "milmove/circleci-docker:${tag}" google-chrome --version
+
+  echo "Passed ${tag}"
+}
+
 function test_milmove_infra() {
   tag=milmove-infra
   echo "Testing ${tag} Dockerfile"
@@ -67,6 +78,9 @@ for tag in latest milmove-app milmove-infra milmove-orders; do
     ;;
     milmove-app)
       test_milmove_app
+    ;;
+    milmove-app-browsers)
+      test_milmove_app_browsers
     ;;
     milmove-infra)
       test_milmove_infra


### PR DESCRIPTION
Add Dockerfile for creating a milmove-app-browsers image with chrome installed. This is to be used with the Loki tests for Storybook stories.

I used the example from the CircleCI Dockerfile for setting this up.
https://github.com/CircleCI-Public/circleci-dockerfiles/blob/master/node/images/10.19.0-buster/browsers/Dockerfile