### PR TITLE
Add a pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+# Description
+
+Explain a little about the changes at a high level.
+
+## Changelog or Releases
+
+Add the changelog or release URL for the tool being updated. Some examples below (delete the ones that do not apply
+for clarity).
+
+- [AWS CLI](https://github.com/aws/aws-cli/blob/v2/CHANGELOG.rst)
+- [chamber](https://github.com/segmentio/chamber/releases)
+- [CircleCI](https://github.com/CircleCI-Public/circleci-cli/releases)
+- [golang](https://golang.org/doc/devel/release.html)
+- [Google Chrome](https://chromereleases.googleblog.com/)
+- [shellcheck](https://github.com/koalaman/shellcheck/releases)
+- [go-bindata](https://github.com/kevinburke/go-bindata/releases)
+- [go-swagger](https://github.com/go-swagger/go-swagger/releases)
+- [node 10.X](https://nodejs.org/en/about/releases/)
+- [pre-commit](https://github.com/pre-commit/pre-commit/releases)
+- [terraform-docs](https://github.com/segmentio/terraform-docs/releases)
+- [terraform](https://github.com/hashicorp/terraform/releases)
+- [yarn](https://github.com/yarnpkg/yarn/releases)


### PR DESCRIPTION
This adds a PR template we can use for any new PRs. The main addition is links to the release notes for tools so we can review the updates more quickly.