### PR TITLE
Add missing dependency for chrome build

### DIFF
--- a/milmove-app-browsers/Dockerfile
+++ b/milmove-app-browsers/Dockerfile
@@ -28,6 +28,7 @@ RUN set -ex && cd ~ \
     libxi6 \
     libxrandr2 \
     libxtst6 \
+    libgbm1 \
     xdg-utils \
   && : Cleanup \
   && apt-get clean \


### PR DESCRIPTION
# Description

The build for `milmove-app-browsers` broke. Seems that now the google chrome install requires `libgbm1` to be available in the image. This PR adds it.

## Changelog or Releases

Add the changelog or release URL for the tool being updated. Some examples below (delete the ones that do not apply
for clarity).

- [Google Chrome](https://chromereleases.googleblog.com/)
