### PR TITLE
Install groff and less for AWS CLI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,10 +63,11 @@ RUN set -ex && cd ~ \
 # apt-get all the things
 # Notes:
 # - Add all apt sources first
+# - groff and less required by AWS CLI
 ARG CACHE_APT
 RUN set -ex && cd ~ \
   && : Install apt packages \
-  && apt-get -qq -y install --no-install-recommends apt-transport-https lsb-release \
+  && apt-get -qq -y install --no-install-recommends apt-transport-https groff less lsb-release \
   && : Cleanup \
   && apt-get clean \
   && rm -vrf /var/lib/apt/lists/*


### PR DESCRIPTION
# Description

AWS CLI requires two utilities for help commands and to show output. Instead of continuing to fight this I'm just adding them to our base images.