### PR TITLE
MB-2473 - Add tfsec to infra container

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,4 +19,5 @@ for clarity).
 - [pre-commit](https://github.com/pre-commit/pre-commit/releases)
 - [terraform-docs](https://github.com/segmentio/terraform-docs/releases)
 - [terraform](https://github.com/hashicorp/terraform/releases)
+- [tfsec](https://github.com/liamg/tfsec/releases)
 - [yarn](https://github.com/yarnpkg/yarn/releases)

--- a/milmove-infra/Dockerfile
+++ b/milmove-infra/Dockerfile
@@ -21,4 +21,13 @@ RUN set -ex && cd ~ \
   && chmod 755 terraform-docs-v${TERRAFORM_DOCS_VERSION}-linux-amd64 \
   && mv terraform-docs-v${TERRAFORM_DOCS_VERSION}-linux-amd64 /usr/local/bin/terraform-docs
 
+# install tfsec
+ARG TFSEC_VERSION=0.19.0
+ARG TFSEC_SHA256SUM=88541fc654dea8f3514c9422003df870f985dc3c50a43c929ab44bb5cee60789
+RUN set -ex && cd ~ \
+  && curl -sSLO https://github.com/liamg/tfsec/releases/download/v${TFSEC_VERSION}/tfsec-linux-amd64 \
+  && [ $(sha256sum tfsec-linux-amd64 | cut -f1 -d' ') = ${TFSEC_SHA256SUM} ] \
+  && chmod 755 tfsec-linux-amd64 \
+  && mv tfsec-linux-amd64 /usr/local/bin/tfsec
+
 USER circleci

--- a/scripts/brew-upgrade
+++ b/scripts/brew-upgrade
@@ -16,6 +16,7 @@ brew upgrade \
     pre-commit \
     shellcheck \
     terraform-docs \
+    liamg/tfsec/tfsec \
     tfenv \
     yarn
 

--- a/scripts/find-updates
+++ b/scripts/find-updates
@@ -76,6 +76,7 @@ function test_milmove_infra() {
 
   compare_version "${tag}" terraform --version
   compare_version "${tag}" terraform-docs --version
+  compare_version "${tag}" tfsec --version
 }
 
 function test_milmove_orders() {
@@ -107,5 +108,4 @@ esac
 
 done
 
-echo "Passed."
 exit 0

--- a/test
+++ b/test
@@ -50,6 +50,7 @@ function test_milmove_infra() {
 
   docker run -it "milmove/circleci-docker:${tag}" terraform --version
   docker run -it "milmove/circleci-docker:${tag}" terraform-docs --version
+  docker run -it "milmove/circleci-docker:${tag}" tfsec --version
 
   echo "Passed ${tag}"
 }


### PR DESCRIPTION
# Description

Adding [tfsec](https://github.com/liamg/tfsec) tool for pre-commit hook.

## Changelog or Releases

Add the changelog or release URL for the tool being updated. Some examples below (delete the ones that do not apply
for clarity).

- [tfsec](https://github.com/liamg/tfsec/releases)
