### PR TITLE
Cg update circleci 0.1.7340 tf 0.12.25 pre commit 2.4.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,8 @@ RUN set -ex && cd ~ \
   && rm -vrf shellcheck-v${SHELLCHECK_VERSION} shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz
 
 # install circleci cli
-ARG CIRCLECI_CLI_VERSION=0.1.7179
-ARG CIRCLECI_CLI_SHA256SUM=c7bf12e7198e7eb797e0a8ee16d18517237d78fc2619e062ad30284f758fc764
+ARG CIRCLECI_CLI_VERSION=0.1.7340
+ARG CIRCLECI_CLI_SHA256SUM=f6f0b9d84654bb76908f21e8c98a68eec54e522e8577887bdbfb3297897a830e
 RUN set -ex && cd ~ \
   && curl -sSLO https://github.com/CircleCI-Public/circleci-cli/releases/download/v${CIRCLECI_CLI_VERSION}/circleci-cli_${CIRCLECI_CLI_VERSION}_linux_amd64.tar.gz \
   && [ $(sha256sum circleci-cli_${CIRCLECI_CLI_VERSION}_linux_amd64.tar.gz | cut -f1 -d' ') = ${CIRCLECI_CLI_SHA256SUM} ] \

--- a/milmove-infra/Dockerfile
+++ b/milmove-infra/Dockerfile
@@ -4,8 +4,8 @@ FROM milmove/circleci-docker:base
 USER root
 
 # install terraform
-ARG TERRAFORM_VERSION=0.12.24
-ARG TERRAFORM_SHA256SUM=602d2529aafdaa0f605c06adb7c72cfb585d8aa19b3f4d8d189b42589e27bf11
+ARG TERRAFORM_VERSION=0.12.25
+ARG TERRAFORM_SHA256SUM=e95daabd1985329f87e6d40ffe7b9b973ff0abc07a403f767e8658d64d733fb0
 RUN set -ex && cd ~ \
   && curl -sSLO https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip \
   && [ $(sha256sum terraform_${TERRAFORM_VERSION}_linux_amd64.zip | cut -f1 -d ' ') = ${TERRAFORM_SHA256SUM} ] \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pre-commit==2.3.0
+pre-commit==2.4.0

--- a/scripts/find-updates
+++ b/scripts/find-updates
@@ -14,6 +14,11 @@ function compare_version () {
   tag=$1
   cmd=("${@:2}")
 
+  if [[ $(docker images -q "milmove/circleci-docker:${tag}" 2> /dev/null) == "" ]]; then
+    echo "Image milmove/circleci-docker:${tag} does not exist!"
+    exit 1
+  fi
+
   # Get the version from inside docker
   dock_v=$(docker run -it --rm "milmove/circleci-docker:${tag}" "${cmd[@]}" | perl -ne '~ s/[^\S\n]+$//g;; print')
 


### PR DESCRIPTION
# Description

Updates:
- pre-commit to 2.4.0
- CircleCI to 0.1.7340
- Terraform to 0.12.25

## Changelog or Releases

- [CircleCI](https://github.com/CircleCI-Public/circleci-cli/releases)
- [pre-commit](https://github.com/pre-commit/pre-commit/releases)
- [terraform](https://github.com/hashicorp/terraform/releases)