### PR TITLE
Add find-guardduty-user to infra container

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,6 +10,7 @@ for clarity).
 - [AWS CLI](https://github.com/aws/aws-cli/blob/v2/CHANGELOG.rst)
 - [chamber](https://github.com/segmentio/chamber/releases)
 - [CircleCI](https://github.com/CircleCI-Public/circleci-cli/releases)
+- [find-guardduty-user](https://github.com/trussworks/find-guardduty-user/releases)
 - [golang](https://golang.org/doc/devel/release.html)
 - [Google Chrome](https://chromereleases.googleblog.com/)
 - [shellcheck](https://github.com/koalaman/shellcheck/releases)

--- a/milmove-infra/Dockerfile
+++ b/milmove-infra/Dockerfile
@@ -30,4 +30,13 @@ RUN set -ex && cd ~ \
   && chmod 755 tfsec-linux-amd64 \
   && mv tfsec-linux-amd64 /usr/local/bin/tfsec
 
+# install find-guardduty-user
+ARG FGU_VERSION=0.0.1
+ARG FGU_SHA256SUM=16ca73c9e34d7903f5541ebd99e9ad5b2a6e2f259c233a875faf7ca892d06713
+RUN set -ex && cd ~ \
+  && curl -sSLO https://github.com/trussworks/find-guardduty-user/releases/download/v${FGU_VERSION}/find-guardduty-user_${FGU_VERSION}_Linux_x86_64.tar.gz \
+  && [ $(sha256sum find-guardduty-user_${FGU_VERSION}_Linux_x86_64.tar.gz | cut -f1 -d' ') = ${FGU_SHA256SUM} ] \
+  && tar -C /usr/local/bin -xzf find-guardduty-user_${FGU_VERSION}_Linux_x86_64.tar.gz \
+  && rm -v find-guardduty-user_${FGU_VERSION}_Linux_x86_64.tar.gz
+
 USER circleci

--- a/test
+++ b/test
@@ -48,6 +48,7 @@ function test_milmove_infra() {
   tag=milmove-infra
   echo "Testing ${tag} Dockerfile"
 
+  docker run -it "milmove/circleci-docker:${tag}" find-guardduty-user version
   docker run -it "milmove/circleci-docker:${tag}" terraform --version
   docker run -it "milmove/circleci-docker:${tag}" terraform-docs --version
   docker run -it "milmove/circleci-docker:${tag}" tfsec --version


### PR DESCRIPTION
# Description

Adds the tool `find-guardduty-user` into the docker image for use with milmove-infra docker image. This should allow real-time use of the tool inside docker for the infra team.

## Changelog or Releases

Add the changelog or release URL for the tool being updated. Some examples below (delete the ones that do not apply
for clarity).

- [find-guardduty-user](https://github.com/trussworks/find-guardduty-user/releases)

## Testing

You can build the images locally and test with

```sh
make build test
```

And if you check the output you'll see:

```sh
$ docker run -it milmove/circleci-docker:milmove-infra find-guardduty-user version
0.0.1
```