### PR TITLE
update terraform to use 0.12.28

### DIFF
--- a/milmove-infra/Dockerfile
+++ b/milmove-infra/Dockerfile
@@ -4,8 +4,8 @@ FROM milmove/circleci-docker:base
 USER root
 
 # install terraform
-ARG TERRAFORM_VERSION=0.12.26
-ARG TERRAFORM_SHA256SUM=607bc802b1c6c2a5e62cc48640f38aaa64bef1501b46f0ae4829feb51594b257
+ARG TERRAFORM_VERSION=0.12.28
+ARG TERRAFORM_SHA256SUM=be99da1439a60942b8d23f63eba1ea05ff42160744116e84f46fc24f1a8011b6
 RUN set -ex && cd ~ \
   && curl -sSLO https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip \
   && [ $(sha256sum terraform_${TERRAFORM_VERSION}_linux_amd64.zip | cut -f1 -d ' ') = ${TERRAFORM_SHA256SUM} ] \


### PR DESCRIPTION
# Description

Update terraform version to latest 0.12.28 from 0.12.26

## Releases Notes from [Terraform's release notes](https://github.com/hashicorp/terraform/releases):

> 0.12.28 (June 25, 2020)
> BUG FIXES:
> 
> build: build the 0.12 version of Terraform with Go 1.12.13, rather than 0.13 Terraform's 1.14.2 (#25386)

![image](https://user-images.githubusercontent.com/5003421/87723807-57c17f80-c788-11ea-9939-a04650c5a2f7.png)
