### PR TITLE
Upgrade go-swagger binary for milmove-app image to version 24

### DIFF
--- a/milmove-app/Dockerfile
+++ b/milmove-app/Dockerfile
@@ -30,8 +30,8 @@ RUN set -ex && cd ~ \
   && mv go-bindata-linux-amd64 /usr/local/bin/go-bindata
 
 # install swagger
-ARG SWAGGER_VERSION=0.21.0
-ARG SWAGGER_SHA256SUM=a50dd0e9db98a6bf9d0794882f24c18c57308963a05b41c44db0c5d295164949
+ARG SWAGGER_VERSION=0.24.0
+ARG SWAGGER_SHA256SUM=50698cc3524e46c805a0a909bb417eaf84cc456dfb162dc2b4e5c6b0d7f6a508
 RUN set -ex && cd ~ \
   && curl -sSLO https://github.com/go-swagger/go-swagger/releases/download/v${SWAGGER_VERSION}/swagger_linux_amd64 \
   && [ $(sha256sum swagger_linux_amd64 | cut -f1 -d' ') = ${SWAGGER_SHA256SUM} ] \


### PR DESCRIPTION
# Description

The mymove app is unable to upgrade its go-openapi dependencies because of an incompatibility introduced in swagger v24.  We can't generate new compatible server structs unless we upgrade the swagger binary from version 21.

[Failing dependency upgrade](https://github.com/transcom/mymove/pull/5029)
[PR to use the new docker image in mymove circleci config and dockerfiles](https://github.com/transcom/mymove/pull/5061)

## Changelog or Releases

[go-swagger v24.0 changelog](https://github.com/go-swagger/go-swagger/releases/tag/v0.24.0):

<img width="779" alt="Screen Shot 2020-10-21 at 2 29 05 PM" src="https://user-images.githubusercontent.com/52669884/96766929-d17d9080-13a9-11eb-98ce-ff1d229dc7d1.png">
