### PR TITLE
No Ticket | Upgrade Pre-commit

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pre-commit==2.6.0
+pre-commit==2.7.1


### PR DESCRIPTION
# Description
https://github.com/transcom/transcom-infrasec-com/pull/1268 that fails in Circle, but doesn't fail locally. Locally, brew upgraded pre-commit to 2.7.1, so this does that.


- [pre-commit](https://github.com/pre-commit/pre-commit/releases)