### PR TITLE
Upgrades go version to 1.15.5

### DIFF
--- a/milmove-app/Dockerfile
+++ b/milmove-app/Dockerfile
@@ -11,8 +11,8 @@ USER root
 ENV GOFLAGS=-p=4
 
 # install go
-ARG GO_VERSION=1.15.4
-ARG GO_SHA256SUM=eb61005f0b932c93b424a3a4eaa67d72196c79129d9a3ea8578047683e2c80d5
+ARG GO_VERSION=1.15.5
+ARG GO_SHA256SUM=9a58494e8da722c3aef248c9227b0e9c528c7318309827780f16220998180a0d
 RUN set -ex && cd ~ \
   && curl -sSLO https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz \
   && [ $(sha256sum go${GO_VERSION}.linux-amd64.tar.gz | cut -f1 -d' ') = ${GO_SHA256SUM} ] \

--- a/milmove-orders/Dockerfile
+++ b/milmove-orders/Dockerfile
@@ -11,8 +11,8 @@ USER root
 ENV GOFLAGS=-p=4
 
 # install go
-ARG GO_VERSION=1.15.4
-ARG GO_SHA256SUM=eb61005f0b932c93b424a3a4eaa67d72196c79129d9a3ea8578047683e2c80d5
+ARG GO_VERSION=1.15.5
+ARG GO_SHA256SUM=9a58494e8da722c3aef248c9227b0e9c528c7318309827780f16220998180a0d
 RUN set -ex && cd ~ \
   && curl -sSLO https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz \
   && [ $(sha256sum go${GO_VERSION}.linux-amd64.tar.gz | cut -f1 -d' ') = ${GO_SHA256SUM} ] \


### PR DESCRIPTION
# Description

Updates go from 1.15.2 to 1.15.5 for minor release that include address some security concerns:
1. go1.15.3 (released 2020/10/14) includes fixes to cgo, the compiler, runtime, the go command, and the bytes, plugin, and testing packages. See the Go 1.15.3 milestone on our issue tracker for details.
1. go1.15.4 (released 2020/11/05) includes fixes to cgo, the compiler, linker, runtime, and the compress/flate, net/http, reflect, and time packages. See the Go 1.15.4 milestone on our issue tracker for details.
1. go1.15.5 (released 2020/11/12) includes security fixes to the cmd/go and math/big packages. See the Go 1.15.5 milestone on our issue tracker for details.

See the [version notes](https://golang.org/doc/devel/release.html) for more release notes.

Verify the checksum [here](https://golang.org/dl/) - `9a58494e8da722c3aef248c9227b0e9c528c7318309827780f16220998180a0d `

[Upgrade Golang Version Wiki](https://github.com/transcom/mymove/wiki/upgrade-go-version)

## Changelog or Releases

- [golang](https://golang.org/doc/devel/release.html)