### PR TITLE
No Ticket | We Need Node

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # CircleCI docker image to run within
-FROM circleci/python:3.9.0-buster
+FROM circleci/python:3.9-buster-node
 # Base image uses "circleci", to avoid using `sudo` run as root user
 USER root
 


### PR DESCRIPTION
# Description
This uses a base image that is Python 3.9 but _also_ node [14.5.1](https://github.com/CircleCI-Public/circleci-dockerfiles/blob/master/python/images/3.9.0-buster/node/Dockerfile#L21) (the latest LTS). I _think_ we need this as a bunch of our pre-commits are failing [here](https://github.com/transcom/transcom-infrasec-gov/pull/174) and [here](https://github.com/transcom/transcom-infrasec-com/pull/1288) and a plethora of others...So this puts node in the container, which should allow us to do do a `npm install` in CircleCI, which will hopefully satisfy pre-commit and allow tests to run, pass, and us ship code. This is largely a test...but I need to merge this to build/publish/tag a docker container. So here's a PR that does that.
