### PR TITLE
Add upstream ecs-service-logs image to the app image

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,6 +11,7 @@ for clarity).
 - [chamber](https://github.com/segmentio/chamber/releases)
 - [cypress](https://www.cypress.io/)
 - [CircleCI](https://github.com/CircleCI-Public/circleci-cli/releases)
+- [ecs-service-logs](https://github.com/trussworks/ecs-service-logs/releases)
 - [find-guardduty-user](https://github.com/trussworks/find-guardduty-user/releases)
 - [golang](https://golang.org/doc/devel/release.html)
 - [Google Chrome](https://chromereleases.googleblog.com/)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,13 @@
 repos:
 -   repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v2.5.0
+    rev: v3.4.0
     hooks:
     -   id: check-merge-conflict
     -   id: detect-private-key
     -   id: trailing-whitespace
 
 -   repo: git://github.com/igorshubovych/markdownlint-cli
-    rev: v0.22.0
+    rev: v0.26.0
     hooks:
     -   id: markdownlint
 

--- a/milmove-app/Dockerfile
+++ b/milmove-app/Dockerfile
@@ -53,6 +53,8 @@ RUN set -ex && cd ~ \
 # - When adding apt sources do it before 'apt-get update'
 ARG CACHE_APT
 RUN set -ex && cd ~ \
+  && : Remove existing node \
+  && rm -rf /usr/local/bin/node /usr/local/bin/nodejs \
   && : Add Node 12.x \
   && curl -sS https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - \
   && echo "deb https://deb.nodesource.com/node_12.x $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/nodesource.list \

--- a/milmove-app/Dockerfile
+++ b/milmove-app/Dockerfile
@@ -39,6 +39,15 @@ RUN set -ex && cd ~ \
   && ls -alh swagger_linux_amd64 \
   && mv swagger_linux_amd64 /usr/local/bin/swagger
 
+ARG ECS_SERVICE_LOGS_VERSION=0.3.0
+ARG ECS_SERVICE_LOGS_SHA256SUM=2803177477bb917a19fc89f36f4972af740f80d35380cbe2c97345bb6d109f8e
+RUN set -ex && cd ~ \
+  && curl -sSLO https://github.com/trussworks/find-guardduty-user/releases/download/v${ECS_SERVICE_LOGS_VERSION}/ecs-service-logs_${ECS_SERVICE_LOGS_VERSION}_Linux_x86_64.tar.gz \
+  && [ $(sha256sum ecs-service-logs_${ECS_SERVICE_LOGS_VERSION}_Linux_x86_64.tar.gz | cut -f1 -d' ') = ${ECS_SERVICE_LOGS_SHA256SUM} ] \
+  && tar -C /usr/local/bin -xzf ecs-service-logs_${ECS_SERVICE_LOGS_VERSION}_Linux_x86_64.tar.gz \
+  && rm -v ecs-service-logs_${ECS_SERVICE_LOGS_VERSION}_Linux_x86_64.tar.gz
+
+
 # apt-get project dependencies
 # Notes:
 # - When adding apt sources do it before 'apt-get update'

--- a/milmove-app/Dockerfile
+++ b/milmove-app/Dockerfile
@@ -42,7 +42,7 @@ RUN set -ex && cd ~ \
 ARG ECS_SERVICE_LOGS_VERSION=0.3.0
 ARG ECS_SERVICE_LOGS_SHA256SUM=2803177477bb917a19fc89f36f4972af740f80d35380cbe2c97345bb6d109f8e
 RUN set -ex && cd ~ \
-  && curl -sSLO https://github.com/trussworks/find-guardduty-user/releases/download/v${ECS_SERVICE_LOGS_VERSION}/ecs-service-logs_${ECS_SERVICE_LOGS_VERSION}_Linux_x86_64.tar.gz \
+  && curl -sSLO https://github.com/trussworks/ecs-service-logs/releases/download/v${ECS_SERVICE_LOGS_VERSION}/ecs-service-logs_${ECS_SERVICE_LOGS_VERSION}_Linux_x86_64.tar.gz \
   && [ $(sha256sum ecs-service-logs_${ECS_SERVICE_LOGS_VERSION}_Linux_x86_64.tar.gz | cut -f1 -d' ') = ${ECS_SERVICE_LOGS_SHA256SUM} ] \
   && tar -C /usr/local/bin -xzf ecs-service-logs_${ECS_SERVICE_LOGS_VERSION}_Linux_x86_64.tar.gz \
   && rm -v ecs-service-logs_${ECS_SERVICE_LOGS_VERSION}_Linux_x86_64.tar.gz


### PR DESCRIPTION
# Description

The ecs-service-logs script has been pulled out into its own repo. This PR adds the binary to the app image because it's required to deploy via circleci.

## Changelog or Releases

- [ecs-service-logs v3.0](https://github.com/trussworks/ecs-service-logs/releases/tag/v0.3.0)
