### PR TITLE
Revert "No Ticket | We Need Node"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # CircleCI docker image to run within
-FROM circleci/python:3.9-buster-node
+FROM circleci/python:3.9.0-buster
 # Base image uses "circleci", to avoid using `sudo` run as root user
 USER root
 


### PR DESCRIPTION
Milmove is still on Node 12 so this reverts transcom/circleci-docker#61