### PR TITLE
add a new infra image for upgrading to terraform 0.13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,10 @@ jobs:
               docker tag  milmove/circleci-docker:milmove-infra milmove/circleci-docker:milmove-infra-$tag
               docker push milmove/circleci-docker:milmove-infra-$tag
 
+              # milmove-infra-tf13
+              docker tag  milmove/circleci-docker:milmove-infra-tf13 milmove/circleci-docker:milmove-infra-tf13-$tag
+              docker push milmove/circleci-docker:milmove-infra-tf13-$tag
+
               # milmove-orders
               docker tag  milmove/circleci-docker:milmove-orders milmove/circleci-docker:milmove-orders-$tag
               docker push milmove/circleci-docker:milmove-orders-$tag
@@ -60,5 +64,6 @@ jobs:
               docker push milmove/circleci-docker:milmove-app-browsers
               docker push milmove/circleci-docker:milmove-cypress
               docker push milmove/circleci-docker:milmove-infra
+              docker push milmove/circleci-docker:milmove-infra-tf13
               docker push milmove/circleci-docker:milmove-orders
             fi

--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -33,6 +33,12 @@ update_configs:
     default_labels:
       - "dependencies"
   - package_manager: "docker"
+    directory: "/milmove-infra-tf13"
+    update_schedule: "weekly"
+    # Apply dependencies label to PRs
+    default_labels:
+      - "dependencies"
+  - package_manager: "docker"
     directory: "/milmove-orders"
     update_schedule: "weekly"
     # Apply dependencies label to PRs

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ For the latest stable images:
 * `milmove/circleci-docker:milmove-app-browsers`
 * `milmove/circleci-docker:milmove-cypress`
 * `milmove/circleci-docker:milmove-infra`
+* `milmove/circleci-docker:milmove-infra-tf13`
 * `milmove/circleci-docker:milmove-orders`
 
 For static tags, use tags including the git hash. You can find the hashes in this repo, from the [CircleCI builds page](https://circleci.com/gh/milmove/circleci-docker/tree/master), or from the [Docker Hub tags](https://hub.docker.com/r/milmove/circleci-docker/tags/) page.
@@ -97,6 +98,7 @@ docker pull milmove/circleci-docker:milmove-app
 docker pull milmove/circleci-docker:milmove-app-browsers
 docker pull milmove/circleci-docker:milmove-cypress
 docker pull milmove/circleci-docker:milmove-infra
+docker pull milmove/circleci-docker:milmove-infra-tf13
 docker pull milmove/circleci-docker:milmove-orders
 
 ```

--- a/build
+++ b/build
@@ -44,6 +44,11 @@ docker build -t milmove/circleci-docker:milmove-infra \
              .
 popd
 
+pushd milmove-infra-tf13
+docker build -t milmove/circleci-docker:milmove-infra-tf13 \
+             .
+popd
+
 pushd milmove-orders
 docker build --build-arg CACHE_APT="$CACHE_APT" \
              --build-arg CACHE_PIP="$CACHE_PIP" \

--- a/milmove-infra-tf13/Dockerfile
+++ b/milmove-infra-tf13/Dockerfile
@@ -1,0 +1,46 @@
+# This is a copy of the milmove-infra Docker image that can be used to allow a
+# sidecar upgrade to Terraform 0.13. Once the upgrade is complete, this image
+# can be deleted and its contents can be moved over to the milmove-infra image.
+
+# CircleCI docker image to run within
+FROM milmove/circleci-docker:base
+# Base image uses "circleci", to avoid using `sudo` run as root user
+USER root
+
+# install terraform
+ARG TERRAFORM_VERSION=0.13.6
+ARG TERRAFORM_SHA256SUM=55f2db00b05675026be9c898bdd3e8230ff0c5c78dd12d743ca38032092abfc9
+RUN set -ex && cd ~ \
+  && curl -sSLO https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip \
+  && [ $(sha256sum terraform_${TERRAFORM_VERSION}_linux_amd64.zip | cut -f1 -d ' ') = ${TERRAFORM_SHA256SUM} ] \
+  && unzip -o -d /usr/local/bin -o terraform_${TERRAFORM_VERSION}_linux_amd64.zip \
+  && rm -vf terraform_${TERRAFORM_VERSION}_linux_amd64.zip
+
+# install terraform-docs
+ARG TERRAFORM_DOCS_VERSION=0.10.1
+ARG TERRAFORM_DOCS_SHA256SUM=37fa36d8340ceebf54f9eda73570ddbccb04fd0a53c133d3deae279161d941a1
+RUN set -ex && cd ~ \
+  && curl -sSLO https://github.com/segmentio/terraform-docs/releases/download/v${TERRAFORM_DOCS_VERSION}/terraform-docs-v${TERRAFORM_DOCS_VERSION}-linux-amd64 \
+  && [ $(sha256sum terraform-docs-v${TERRAFORM_DOCS_VERSION}-linux-amd64 | cut -f1 -d' ') = ${TERRAFORM_DOCS_SHA256SUM} ] \
+  && chmod 755 terraform-docs-v${TERRAFORM_DOCS_VERSION}-linux-amd64 \
+  && mv terraform-docs-v${TERRAFORM_DOCS_VERSION}-linux-amd64 /usr/local/bin/terraform-docs
+
+# install tfsec
+ARG TFSEC_VERSION=0.37.2
+ARG TFSEC_SHA256SUM=bd3fc58aad65b32eb4f4411770fcc442a324f6191e3723207f644cb6207b9cff
+RUN set -ex && cd ~ \
+  && curl -sSLO https://github.com/liamg/tfsec/releases/download/v${TFSEC_VERSION}/tfsec-linux-amd64 \
+  && [ $(sha256sum tfsec-linux-amd64 | cut -f1 -d' ') = ${TFSEC_SHA256SUM} ] \
+  && chmod 755 tfsec-linux-amd64 \
+  && mv tfsec-linux-amd64 /usr/local/bin/tfsec
+
+# install find-guardduty-user
+ARG FGU_VERSION=0.0.3
+ARG FGU_SHA256SUM=46ef5914b4e8761517d5cd5b181ca74f4705ae6c2a897bc820ab778aca5e8805
+RUN set -ex && cd ~ \
+  && curl -sSLO https://github.com/trussworks/find-guardduty-user/releases/download/v${FGU_VERSION}/find-guardduty-user_${FGU_VERSION}_Linux_x86_64.tar.gz \
+  && [ $(sha256sum find-guardduty-user_${FGU_VERSION}_Linux_x86_64.tar.gz | cut -f1 -d' ') = ${FGU_SHA256SUM} ] \
+  && tar -C /usr/local/bin -xzf find-guardduty-user_${FGU_VERSION}_Linux_x86_64.tar.gz \
+  && rm -v find-guardduty-user_${FGU_VERSION}_Linux_x86_64.tar.gz
+
+USER circleci

--- a/scripts/find-updates
+++ b/scripts/find-updates
@@ -84,6 +84,16 @@ function test_milmove_infra() {
   compare_version "${tag}" tfsec --version
 }
 
+function test_milmove_infra_tf13() {
+  tag=milmove-infra-tf13
+  echo
+  echo "Comparing against ${tag} Dockerfile"
+
+  compare_version "${tag}" terraform --version
+  compare_version "${tag}" terraform-docs --version
+  compare_version "${tag}" tfsec --version
+}
+
 function test_milmove_orders() {
   tag=milmove-orders
   echo
@@ -105,6 +115,9 @@ for tag in latest milmove-app milmove-app-browsers milmove-infra milmove-orders;
     ;;
     milmove-infra)
       test_milmove_infra
+    ;;
+    milmove-infra-tf13)
+      test_milmove_infra_tf13
     ;;
     milmove-orders)
       test_milmove_orders

--- a/test
+++ b/test
@@ -65,6 +65,18 @@ function test_milmove_infra() {
   echo "Passed ${tag}"
 }
 
+function test_milmove_infra_tf13() {
+  tag=milmove-infra-tf13
+  echo "Testing ${tag} Dockerfile"
+
+  docker run -it "milmove/circleci-docker:${tag}" find-guardduty-user version
+  docker run -it "milmove/circleci-docker:${tag}" terraform --version
+  docker run -it "milmove/circleci-docker:${tag}" terraform-docs --version
+  docker run -it "milmove/circleci-docker:${tag}" tfsec --version
+
+  echo "Passed ${tag}"
+}
+
 function test_milmove_orders() {
   tag=milmove-orders
   echo "Testing ${tag} Dockerfile"
@@ -77,7 +89,7 @@ function test_milmove_orders() {
   echo "Passed ${tag}"
 }
 
-for tag in latest milmove-app milmove-app-browsers milmove-cypress milmove-infra milmove-orders; do
+for tag in latest milmove-app milmove-app-browsers milmove-cypress milmove-infra milmove-infra-tf13 milmove-orders; do
   echo
   echo "* Testing USER is properly set to 'circleci' on '${tag}' tagged image"
   docker run -it "milmove/circleci-docker:${tag}" bash -xc '[[ $(whoami) = circleci ]]'
@@ -97,6 +109,9 @@ for tag in latest milmove-app milmove-app-browsers milmove-cypress milmove-infra
     ;;
     milmove-infra)
       test_milmove_infra
+    ;;
+    milmove-infra-tf13)
+      test_milmove_infra_tf13
     ;;
     milmove-orders)
       test_milmove_orders


### PR DESCRIPTION
# Description

This creates a copy of the milmove-infra Docker image that can be used to allow a sidecar upgrade to Terraform 0.13. This makes it so we can leave everything as it exists for code that expects Terraform 0.12, but for code that expects Terraform 0.13, we can point to this image. Once the Terraform 0.13 upgrade is complete, this image can be deleted and its contents can be moved over to the milmove-infra image.

## Changelog or Releases

Add the changelog or release URL for the tool being updated. Some examples below (delete the ones that do not apply
for clarity).

- [CircleCI](https://github.com/CircleCI-Public/circleci-cli/releases)
- [find-guardduty-user](https://github.com/trussworks/find-guardduty-user/releases)
- [terraform-docs](https://github.com/segmentio/terraform-docs/releases)
- [terraform](https://github.com/hashicorp/terraform/releases)
- [tfsec](https://github.com/liamg/tfsec/releases)
