### PR TITLE
[MB-6392] Remove moment from Cypress dependencies

### DIFF
--- a/milmove-cypress/package.json
+++ b/milmove-cypress/package.json
@@ -8,7 +8,6 @@
     "cypress-multi-reporters": "^1.2.3",
     "cypress-wait-until": "^1.7.1",
     "mocha": "^8.2.1",
-    "mocha-junit-reporter": "^2.0.0",
-    "moment": "^2.29.1"
+    "mocha-junit-reporter": "^2.0.0"
   }
 }


### PR DESCRIPTION
# Description

As of https://github.com/transcom/mymove/pull/5879 we are replacing Moment.js with another date library. The Cypress image in this repo had Moment listed as a dependency, but we were not actually using Moment in any Cypress code, so I am deleting it outright.