### PR TITLE
MB-6644 Update go version to 1.15.8

### DIFF
--- a/milmove-app/Dockerfile
+++ b/milmove-app/Dockerfile
@@ -11,8 +11,8 @@ USER root
 ENV GOFLAGS=-p=4
 
 # install go
-ARG GO_VERSION=1.15.5
-ARG GO_SHA256SUM=9a58494e8da722c3aef248c9227b0e9c528c7318309827780f16220998180a0d
+ARG GO_VERSION=1.15.8
+ARG GO_SHA256SUM=d3379c32a90fdf9382166f8f48034c459a8cc433730bc9476d39d9082c94583b
 RUN set -ex && cd ~ \
   && curl -sSLO https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz \
   && [ $(sha256sum go${GO_VERSION}.linux-amd64.tar.gz | cut -f1 -d' ') = ${GO_SHA256SUM} ] \

--- a/milmove-orders/Dockerfile
+++ b/milmove-orders/Dockerfile
@@ -11,8 +11,8 @@ USER root
 ENV GOFLAGS=-p=4
 
 # install go
-ARG GO_VERSION=1.15.5
-ARG GO_SHA256SUM=9a58494e8da722c3aef248c9227b0e9c528c7318309827780f16220998180a0d
+ARG GO_VERSION=1.15.8
+ARG GO_SHA256SUM=d3379c32a90fdf9382166f8f48034c459a8cc433730bc9476d39d9082c94583b
 RUN set -ex && cd ~ \
   && curl -sSLO https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz \
   && [ $(sha256sum go${GO_VERSION}.linux-amd64.tar.gz | cut -f1 -d' ') = ${GO_SHA256SUM} ] \


### PR DESCRIPTION
# Description

Update go from 1.15.5 to 1.15.8. Includes release with security fixes.

Following instructions from https://github.com/transcom/mymove/wiki/upgrade-go-version

## Changelog or Releases

1. [golang](https://golang.org/doc/devel/release.html)

    1. go1.15.6 (released 2020/12/03) includes fixes to the compiler, linker, runtime, the go command, and the io package. See the Go 1.15.6 milestone on our issue tracker for details.

    1. go1.15.7 (released 2021/01/19) includes security fixes to the go command and the crypto/elliptic package. See the Go 1.15.7 milestone on our issue tracker for details.

    1. go1.15.8 (released 2021/02/04) includes fixes to the compiler, linker, runtime, the go command, and the net/http package. See the Go 1.15.8 milestone on our issue tracker for details.
