### PR TITLE
MB-6744: bump primary infra image to tf 0.13

### DIFF
--- a/milmove-infra-tf13/Dockerfile
+++ b/milmove-infra-tf13/Dockerfile
@@ -29,7 +29,7 @@ RUN set -ex && cd ~ \
 ARG TFSEC_VERSION=0.37.2
 ARG TFSEC_SHA256SUM=bd3fc58aad65b32eb4f4411770fcc442a324f6191e3723207f644cb6207b9cff
 RUN set -ex && cd ~ \
-  && curl -sSLO https://github.com/liamg/tfsec/releases/download/v${TFSEC_VERSION}/tfsec-linux-amd64 \
+  && curl -sSLO https://github.com/tfsec/tfsec/releases/download/v${TFSEC_VERSION}/tfsec-linux-amd64 \
   && [ $(sha256sum tfsec-linux-amd64 | cut -f1 -d' ') = ${TFSEC_SHA256SUM} ] \
   && chmod 755 tfsec-linux-amd64 \
   && mv tfsec-linux-amd64 /usr/local/bin/tfsec

--- a/milmove-infra/Dockerfile
+++ b/milmove-infra/Dockerfile
@@ -4,8 +4,8 @@ FROM milmove/circleci-docker:base
 USER root
 
 # install terraform
-ARG TERRAFORM_VERSION=0.12.29
-ARG TERRAFORM_SHA256SUM=872245d9c6302b24dc0d98a1e010aef1e4ef60865a2d1f60102c8ad03e9d5a1d
+ARG TERRAFORM_VERSION=0.13.6
+ARG TERRAFORM_SHA256SUM=55f2db00b05675026be9c898bdd3e8230ff0c5c78dd12d743ca38032092abfc9
 RUN set -ex && cd ~ \
   && curl -sSLO https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip \
   && [ $(sha256sum terraform_${TERRAFORM_VERSION}_linux_amd64.zip | cut -f1 -d ' ') = ${TERRAFORM_SHA256SUM} ] \
@@ -22,8 +22,8 @@ RUN set -ex && cd ~ \
   && mv terraform-docs-v${TERRAFORM_DOCS_VERSION}-linux-amd64 /usr/local/bin/terraform-docs
 
 # install tfsec
-ARG TFSEC_VERSION=0.27.0
-ARG TFSEC_SHA256SUM=16b4ef11d64f86c91017a87db7fcba89690adb0e5c0bc47e709d324682dc1732
+ARG TFSEC_VERSION=0.37.2
+ARG TFSEC_SHA256SUM=bd3fc58aad65b32eb4f4411770fcc442a324f6191e3723207f644cb6207b9cff
 RUN set -ex && cd ~ \
   && curl -sSLO https://github.com/tfsec/tfsec/releases/download/v${TFSEC_VERSION}/tfsec-linux-amd64 \
   && [ $(sha256sum tfsec-linux-amd64 | cut -f1 -d' ') = ${TFSEC_SHA256SUM} ] \
@@ -31,8 +31,8 @@ RUN set -ex && cd ~ \
   && mv tfsec-linux-amd64 /usr/local/bin/tfsec
 
 # install find-guardduty-user
-ARG FGU_VERSION=0.0.1
-ARG FGU_SHA256SUM=16ca73c9e34d7903f5541ebd99e9ad5b2a6e2f259c233a875faf7ca892d06713
+ARG FGU_VERSION=0.0.3
+ARG FGU_SHA256SUM=46ef5914b4e8761517d5cd5b181ca74f4705ae6c2a897bc820ab778aca5e8805
 RUN set -ex && cd ~ \
   && curl -sSLO https://github.com/trussworks/find-guardduty-user/releases/download/v${FGU_VERSION}/find-guardduty-user_${FGU_VERSION}_Linux_x86_64.tar.gz \
   && [ $(sha256sum find-guardduty-user_${FGU_VERSION}_Linux_x86_64.tar.gz | cut -f1 -d' ') = ${FGU_SHA256SUM} ] \


### PR DESCRIPTION
# Description

Pull in the updates from the infra-tf13 image so that the primary infra image is also on terraform 0.13.

## Changelog or Releases

- [terraform](https://github.com/hashicorp/terraform/releases)
- [tfsec](https://github.com/tfsec/tfsec/releases)