### PR TITLE
MB-6495: convert the terraform 0.13 image to a 0.14 image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,9 +48,9 @@ jobs:
               docker tag  milmove/circleci-docker:milmove-infra milmove/circleci-docker:milmove-infra-$tag
               docker push milmove/circleci-docker:milmove-infra-$tag
 
-              # milmove-infra-tf13
-              docker tag  milmove/circleci-docker:milmove-infra-tf13 milmove/circleci-docker:milmove-infra-tf13-$tag
-              docker push milmove/circleci-docker:milmove-infra-tf13-$tag
+              # milmove-infra-tf14
+              docker tag  milmove/circleci-docker:milmove-infra-tf14 milmove/circleci-docker:milmove-infra-tf14-$tag
+              docker push milmove/circleci-docker:milmove-infra-tf14-$tag
 
               # milmove-atlantis
               docker tag  milmove/circleci-docker:milmove-atlantis milmove/circleci-docker:milmove-atlantis-$tag
@@ -64,6 +64,6 @@ jobs:
               docker push milmove/circleci-docker:milmove-app-browsers
               docker push milmove/circleci-docker:milmove-cypress
               docker push milmove/circleci-docker:milmove-infra
-              docker push milmove/circleci-docker:milmove-infra-tf13
+              docker push milmove/circleci-docker:milmove-infra-tf14
               docker push milmove/circleci-docker:milmove-atlantis
             fi

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -57,7 +57,7 @@ updates:
   labels:
   - dependencies
 - package-ecosystem: docker
-  directory: "/milmove-infra-tf13"
+  directory: "/milmove-infra-tf14"
   schedule:
     interval: daily
     time: "11:00"

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ For the latest stable images:
 * `milmove/circleci-docker:milmove-app-browsers`
 * `milmove/circleci-docker:milmove-cypress`
 * `milmove/circleci-docker:milmove-infra`
-* `milmove/circleci-docker:milmove-infra-tf13`
+* `milmove/circleci-docker:milmove-infra-tf14`
 * `milmove/circleci-docker:milmove-atlantis`
 
 For static tags, use tags including the git hash. You can find the hashes in this repo, from the [CircleCI builds page](https://circleci.com/gh/milmove/circleci-docker/tree/master), or from the [Docker Hub tags](https://hub.docker.com/r/milmove/circleci-docker/tags/) page.
@@ -100,7 +100,7 @@ docker pull milmove/circleci-docker:milmove-app
 docker pull milmove/circleci-docker:milmove-app-browsers
 docker pull milmove/circleci-docker:milmove-cypress
 docker pull milmove/circleci-docker:milmove-infra
-docker pull milmove/circleci-docker:milmove-infra-tf13
+docker pull milmove/circleci-docker:milmove-infra-tf14
 docker pull milmove/circleci-docker:milmove-atlantis
 
 ```

--- a/build
+++ b/build
@@ -44,8 +44,8 @@ docker build -t milmove/circleci-docker:milmove-infra \
              .
 popd
 
-pushd milmove-infra-tf13
-docker build -t milmove/circleci-docker:milmove-infra-tf13 \
+pushd milmove-infra-tf14
+docker build -t milmove/circleci-docker:milmove-infra-tf14 \
              .
 popd
 

--- a/milmove-infra-tf14/Dockerfile
+++ b/milmove-infra-tf14/Dockerfile
@@ -18,7 +18,7 @@ RUN set -ex && cd ~ \
 
 # install terraform-docs
 ARG TERRAFORM_DOCS_VERSION=0.12.1
-ARG TERRAFORM_DOCS_SHA256SUM=4bfab3b2d5bfd4f05b7256ca17d3df0ff7783991af480ddb709713f7698d7d46
+ARG TERRAFORM_DOCS_SHA256SUM=32c0611a33a9c83857240ce2095287a5329564f26acd04818da5156192ecf401
 RUN set -ex && cd ~ \
   && curl -sSLO https://github.com/segmentio/terraform-docs/releases/download/v${TERRAFORM_DOCS_VERSION}/terraform-docs-v${TERRAFORM_DOCS_VERSION}-linux-amd64 \
   && [ $(sha256sum terraform-docs-v${TERRAFORM_DOCS_VERSION}-linux-amd64 | cut -f1 -d' ') = ${TERRAFORM_DOCS_SHA256SUM} ] \

--- a/milmove-infra-tf14/Dockerfile
+++ b/milmove-infra-tf14/Dockerfile
@@ -26,7 +26,7 @@ RUN set -ex && cd ~ \
   && mv terraform-docs-v${TERRAFORM_DOCS_VERSION}-linux-amd64 /usr/local/bin/terraform-docs
 
 # install tfsec
-ARG TFSEC_VERSION=0.39.2
+ARG TFSEC_VERSION=0.39.20
 ARG TFSEC_SHA256SUM=3114ff66ecd42d56e17ae47dfb78bd586c3f2a05d7a32bbda4ab8781ec7411f7
 RUN set -ex && cd ~ \
   && curl -sSLO https://github.com/tfsec/tfsec/releases/download/v${TFSEC_VERSION}/tfsec-linux-amd64 \

--- a/milmove-infra-tf14/Dockerfile
+++ b/milmove-infra-tf14/Dockerfile
@@ -8,8 +8,8 @@ FROM milmove/circleci-docker:base
 USER root
 
 # install terraform
-ARG TERRAFORM_VERSION=0.13.6
-ARG TERRAFORM_SHA256SUM=55f2db00b05675026be9c898bdd3e8230ff0c5c78dd12d743ca38032092abfc9
+ARG TERRAFORM_VERSION=0.14.9
+ARG TERRAFORM_SHA256SUM=47e097cfbfb64e97492934f50e646cb84df952eb76897182557811b45603dbf0
 RUN set -ex && cd ~ \
   && curl -sSLO https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip \
   && [ $(sha256sum terraform_${TERRAFORM_VERSION}_linux_amd64.zip | cut -f1 -d ' ') = ${TERRAFORM_SHA256SUM} ] \
@@ -17,8 +17,8 @@ RUN set -ex && cd ~ \
   && rm -vf terraform_${TERRAFORM_VERSION}_linux_amd64.zip
 
 # install terraform-docs
-ARG TERRAFORM_DOCS_VERSION=0.11.2
-ARG TERRAFORM_DOCS_SHA256SUM=0d1e42d6fcb15b14027ae8efb794edb1cd7faa7a32507ccad449340529d04937
+ARG TERRAFORM_DOCS_VERSION=0.12.1
+ARG TERRAFORM_DOCS_SHA256SUM=4bfab3b2d5bfd4f05b7256ca17d3df0ff7783991af480ddb709713f7698d7d46
 RUN set -ex && cd ~ \
   && curl -sSLO https://github.com/segmentio/terraform-docs/releases/download/v${TERRAFORM_DOCS_VERSION}/terraform-docs-v${TERRAFORM_DOCS_VERSION}-linux-amd64 \
   && [ $(sha256sum terraform-docs-v${TERRAFORM_DOCS_VERSION}-linux-amd64 | cut -f1 -d' ') = ${TERRAFORM_DOCS_SHA256SUM} ] \
@@ -26,8 +26,8 @@ RUN set -ex && cd ~ \
   && mv terraform-docs-v${TERRAFORM_DOCS_VERSION}-linux-amd64 /usr/local/bin/terraform-docs
 
 # install tfsec
-ARG TFSEC_VERSION=0.37.2
-ARG TFSEC_SHA256SUM=bd3fc58aad65b32eb4f4411770fcc442a324f6191e3723207f644cb6207b9cff
+ARG TFSEC_VERSION=0.39.2
+ARG TFSEC_SHA256SUM=3114ff66ecd42d56e17ae47dfb78bd586c3f2a05d7a32bbda4ab8781ec7411f7
 RUN set -ex && cd ~ \
   && curl -sSLO https://github.com/tfsec/tfsec/releases/download/v${TFSEC_VERSION}/tfsec-linux-amd64 \
   && [ $(sha256sum tfsec-linux-amd64 | cut -f1 -d' ') = ${TFSEC_SHA256SUM} ] \

--- a/scripts/find-updates
+++ b/scripts/find-updates
@@ -84,8 +84,8 @@ function test_milmove_infra() {
   compare_version "${tag}" tfsec --version
 }
 
-function test_milmove_infra_tf13() {
-  tag=milmove-infra-tf13
+function test_milmove_infra_tf14() {
+  tag=milmove-infra-tf14
   echo
   echo "Comparing against ${tag} Dockerfile"
 
@@ -116,8 +116,8 @@ for tag in latest milmove-app milmove-app-browsers milmove-infra; do
     milmove-infra)
       test_milmove_infra
     ;;
-    milmove-infra-tf13)
-      test_milmove_infra_tf13
+    milmove-infra-tf14)
+      test_milmove_infra_tf14
     ;;
     milmove-atlantis)
       test_milmove_atlantis

--- a/test
+++ b/test
@@ -65,8 +65,8 @@ function test_milmove_infra() {
   echo "Passed ${tag}"
 }
 
-function test_milmove_infra_tf13() {
-  tag=milmove-infra-tf13
+function test_milmove_infra_tf14() {
+  tag=milmove-infra-tf14
   echo "Testing ${tag} Dockerfile"
 
   docker run -it "milmove/circleci-docker:${tag}" find-guardduty-user version
@@ -77,7 +77,7 @@ function test_milmove_infra_tf13() {
   echo "Passed ${tag}"
 }
 
-for tag in latest milmove-app milmove-app-browsers milmove-cypress milmove-infra milmove-infra-tf13; do
+for tag in latest milmove-app milmove-app-browsers milmove-cypress milmove-infra milmove-infra-tf14; do
   echo
   echo "* Testing USER is properly set to 'circleci' on '${tag}' tagged image"
   docker run -it "milmove/circleci-docker:${tag}" bash -xc '[[ $(whoami) = circleci ]]'
@@ -98,8 +98,8 @@ for tag in latest milmove-app milmove-app-browsers milmove-cypress milmove-infra
     milmove-infra)
       test_milmove_infra
     ;;
-    milmove-infra-tf13)
-      test_milmove_infra_tf13
+    milmove-infra-tf14)
+      test_milmove_infra_tf14
     ;;
 esac
 


### PR DESCRIPTION
# Description

The main infra image uses Terraform 0.13. This PR converts the distinct Terraform 0.13 image to a Terraform 0.14 image, which can be used during the process of upgrading other repositories to use Terraform 0.14.

This also upgrades terrafrom-docs and tfsec to the latest available versions.

## Changelog or Releases

- [terraform-docs](https://github.com/segmentio/terraform-docs/releases)
- [terraform](https://github.com/hashicorp/terraform/releases)
- [tfsec](https://github.com/tfsec/tfsec/releases)