### PR TITLE
Update cypress to 7.1

### DIFF
--- a/milmove-cypress/package.json
+++ b/milmove-cypress/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.1.0",
   "devDependencies": {
-    "cypress": "^7.0.1",
+    "cypress": "^7.1.0",
     "cypress-audit": "^0.3.0",
     "cypress-multi-reporters": "^1.2.3",
     "cypress-wait-until": "^1.7.1",

--- a/milmove-cypress/yarn.lock
+++ b/milmove-cypress/yarn.lock
@@ -679,7 +679,7 @@ cypress-wait-until@^1.7.1:
   resolved "https://registry.yarnpkg.com/cypress-wait-until/-/cypress-wait-until-1.7.1.tgz#3789cd18affdbb848e3cfc1f918353c7ba1de6f8"
   integrity sha512-8DL5IsBTbAxBjfYgCzdbohPq/bY+IKc63fxtso1C8RWhLnQkZbVESyaclNr76jyxfId6uyzX8+Xnt0ZwaXNtkA==
 
-cypress@^7.0.1:
+cypress@^7.1.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/cypress/-/cypress-7.1.0.tgz#6cb5dc22c6271a9d7a79a2477251a95afc77e531"
   integrity sha512-AptQP9fVtN/FfOv8rJ9hTGJE2XQFc8saLHT38r/EeyWhzp0q/+P/DYRTDtjGZHeLTCNznAUrT4lal8jm+ouS7Q==


### PR DESCRIPTION
# Description

Update Cypress to 7.1 for `milmove-cypress`

## Changelog or Releases

Add the changelog or release URL for the tool being updated. Some examples below (delete the ones that do not apply
for clarity).

- [AWS CLI](https://github.com/aws/aws-cli/blob/v2/CHANGELOG.rst)
- [chamber](https://github.com/segmentio/chamber/releases)
- [cypress](https://www.cypress.io/)
- [CircleCI](https://github.com/CircleCI-Public/circleci-cli/releases)
- [ecs-service-logs](https://github.com/trussworks/ecs-service-logs/releases)
- [find-guardduty-user](https://github.com/trussworks/find-guardduty-user/releases)
- [golang](https://golang.org/doc/devel/release.html)
- [Google Chrome](https://chromereleases.googleblog.com/)
- [shellcheck](https://github.com/koalaman/shellcheck/releases)
- [go-bindata](https://github.com/kevinburke/go-bindata/releases)
- [go-swagger](https://github.com/go-swagger/go-swagger/releases)
- [node 10.X](https://nodejs.org/en/about/releases/)
- [pre-commit](https://github.com/pre-commit/pre-commit/releases)
- [terraform-docs](https://github.com/segmentio/terraform-docs/releases)
- [terraform](https://github.com/hashicorp/terraform/releases)
- [tfsec](https://github.com/tfsec/tfsec/releases)
- [yarn](https://github.com/yarnpkg/yarn/releases)
