### PR TITLE
[MB-8087] Update go version to 1.16.4

### DIFF
--- a/milmove-app/Dockerfile
+++ b/milmove-app/Dockerfile
@@ -11,8 +11,8 @@ USER root
 ENV GOFLAGS=-p=4
 
 # install go
-ARG GO_VERSION=1.15.10
-ARG GO_SHA256SUM=4aa1267517df32f2bf1cc3d55dfc27d0c6b2c2b0989449c96dd19273ccca051d
+ARG GO_VERSION=1.16.4
+ARG GO_SHA256SUM=7154e88f5a8047aad4b80ebace58a059e36e7e2e4eb3b383127a28c711b4ff59
 RUN set -ex && cd ~ \
   && curl -sSLO https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz \
   && [ $(sha256sum go${GO_VERSION}.linux-amd64.tar.gz | cut -f1 -d' ') = ${GO_SHA256SUM} ] \


### PR DESCRIPTION
# Description

Update go from 1.15.10 to 1.16.4 in our docker images in anticipation of switching to Go 1.16.x in milmove.  This includes security fixes released in 1.16.4/1.15.12.

JIRA story: https://dp3.atlassian.net/browse/MB-8087

## Changelog or Releases

Go 1.16 release notes:
https://golang.org/doc/go1.16

Go 1.16.x version history:
https://golang.org/doc/devel/release.html#go1.16
