### PR TITLE
MB-8096: Upgrade Atlantis for exp

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,6 +8,7 @@ Add the changelog or release URL for the tool being updated. Some examples below
 for clarity).
 
 - [AWS CLI](https://github.com/aws/aws-cli/blob/v2/CHANGELOG.rst)
+- [atl🍑ntis](https://github.com/runatlantis/atlantis/releases)
 - [chamber](https://github.com/segmentio/chamber/releases)
 - [cypress](https://www.cypress.io/)
 - [CircleCI](https://github.com/CircleCI-Public/circleci-cli/releases)

--- a/milmove-atlantis/Dockerfile
+++ b/milmove-atlantis/Dockerfile
@@ -1,4 +1,4 @@
-FROM runatlantis/atlantis:v0.16.1
+FROM runatlantis/atlantis:v0.17.0
 # This image installs this ^----- particular version of atlantis
 # at /usr/local/bin/atlantis and several versions of terraform.
 # See: https://github.com/runatlantis/atlantis/releases and
@@ -8,6 +8,9 @@ FROM runatlantis/atlantis:v0.16.1
 # DEFAULT_TERRAFORM_VERSION environment variable in the container
 # See: https://github.com/runatlantis/atlantis/blob/master/Dockerfile
 # for available versions
+
+# # install terraform binaries
+ENV DEFAULT_TERRAFORM_VERSION=0.15.4
 
 # Bust the cache before running non-repeatable commands
 ARG version

--- a/milmove-atlantis/Dockerfile
+++ b/milmove-atlantis/Dockerfile
@@ -1,4 +1,4 @@
-FROM runatlantis/atlantis:v0.16.1
+FROM runatlantis/atlantis:v0.17.0
 # This image installs this ^----- particular version of atlantis
 # at /usr/local/bin/atlantis and several versions of terraform.
 # See: https://github.com/runatlantis/atlantis/releases and
@@ -8,6 +8,9 @@ FROM runatlantis/atlantis:v0.16.1
 # DEFAULT_TERRAFORM_VERSION environment variable in the container
 # See: https://github.com/runatlantis/atlantis/blob/master/Dockerfile
 # for available versions
+
+# install terraform binaries
+ENV DEFAULT_TERRAFORM_VERSION=0.15.4
 
 # Bust the cache before running non-repeatable commands
 ARG version

--- a/milmove-atlantis/Dockerfile
+++ b/milmove-atlantis/Dockerfile
@@ -1,4 +1,4 @@
-FROM runatlantis/atlantis:v0.17.0
+FROM runatlantis/atlantis:v0.16.1
 # This image installs this ^----- particular version of atlantis
 # at /usr/local/bin/atlantis and several versions of terraform.
 # See: https://github.com/runatlantis/atlantis/releases and
@@ -8,9 +8,6 @@ FROM runatlantis/atlantis:v0.17.0
 # DEFAULT_TERRAFORM_VERSION environment variable in the container
 # See: https://github.com/runatlantis/atlantis/blob/master/Dockerfile
 # for available versions
-
-# install terraform binaries
-ENV DEFAULT_TERRAFORM_VERSION=0.15.4
 
 # Bust the cache before running non-repeatable commands
 ARG version


### PR DESCRIPTION
# ## [Upgrade TF modules in `transcom-gov-milmove-exp`](https://dp3.atlassian.net/browse/MB-6975)

Upgrades Atlantis so it can run on TF 15 in `transcom-gov-milmove-exp`

## Changelog or Releases

Add the changelog or release URL for the tool being updated. Some examples below (delete the ones that do not apply
for clarity).

- [atl🍑ntis](https://github.com/runatlantis/atlantis/releases)
- [terraform](https://github.com/hashicorp/terraform/releases) (indirectly)
