### PR TITLE
Upgrade Atlantis

### DIFF
--- a/milmove-atlantis/Dockerfile
+++ b/milmove-atlantis/Dockerfile
@@ -9,9 +9,6 @@ FROM runatlantis/atlantis:v0.17.0
 # See: https://github.com/runatlantis/atlantis/blob/master/Dockerfile
 # for available versions
 
-# # install terraform binaries
-ENV DEFAULT_TERRAFORM_VERSION=0.15.4
-
 # Bust the cache before running non-repeatable commands
 ARG version
 


### PR DESCRIPTION
### [Upgrade TF modules in `transcom-gov-milmove-exp`](https://dp3.atlassian.net/browse/MB-6975)

Removes default version env var as it's not necessary for us right now (also 0.15.3 is still latest...). 
I mistakenly thought this was needed to build. This takes it out and makes our code cleaner. 🧹 