### PR TITLE
Upgrade golang to 1.16.5

### DIFF
--- a/milmove-app/Dockerfile
+++ b/milmove-app/Dockerfile
@@ -11,8 +11,8 @@ USER root
 ENV GOFLAGS=-p=4
 
 # install go
-ARG GO_VERSION=1.16.4
-ARG GO_SHA256SUM=7154e88f5a8047aad4b80ebace58a059e36e7e2e4eb3b383127a28c711b4ff59
+ARG GO_VERSION=1.16.5
+ARG GO_SHA256SUM=b12c23023b68de22f74c0524f10b753e7b08b1504cb7e417eccebdd3fae49061
 RUN set -ex && cd ~ \
   && curl -sSLO https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz \
   && [ $(sha256sum go${GO_VERSION}.linux-amd64.tar.gz | cut -f1 -d' ') = ${GO_SHA256SUM} ] \


### PR DESCRIPTION
# Description

Update go from 1.16.4 to 1.16.5 in our docker images in anticipation of switching to Go 1.16.5 in milmove. This includes security fixes released in 1.16.5.

To verify that go 1.16.5 is in the container, do the following:

1. `docker pull milmove/circleci-docker:milmove-app-12e26fdb58826aaa595111fd3793c2c00c1abda9` (to pull down the image -- that hash matches the commit hash in this PR)
1. `docker images` (to see the current image list -- make note of the image ID for the image above)
1. `docker run -it <image ID> /bin/bash` (to run an interactive shell with that image)
1. While in the interactive shell, do a `go version` and verify that it says `1.16.5`
1. `exit` to get out of the interactive shell

## Changelog or Releases

Go 1.16.x version history:
https://golang.org/doc/devel/release.html#go1.16
