### PR TITLE
[MB-8828] Upgrade golang to 1.16.6

### DIFF
--- a/milmove-app/Dockerfile
+++ b/milmove-app/Dockerfile
@@ -11,8 +11,8 @@ USER root
 ENV GOFLAGS=-p=4
 
 # install go
-ARG GO_VERSION=1.16.5
-ARG GO_SHA256SUM=b12c23023b68de22f74c0524f10b753e7b08b1504cb7e417eccebdd3fae49061
+ARG GO_VERSION=1.16.6
+ARG GO_SHA256SUM=be333ef18b3016e9d7cb7b1ff1fdb0cac800ca0be4cf2290fe613b3d069dfe0d
 RUN set -ex && cd ~ \
   && curl -sSLO https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz \
   && [ $(sha256sum go${GO_VERSION}.linux-amd64.tar.gz | cut -f1 -d' ') = ${GO_SHA256SUM} ] \


### PR DESCRIPTION
# Description

Update go from 1.16.5 to 1.16.6 in our docker images in anticipation of switching to Go 1.16.6 in milmove. This includes security fixes released in 1.16.6.

To verify that go 1.16.6 is in the container, do the following:

1. `docker pull milmove/circleci-docker:milmove-app-d70c4d3c4457884822f04aca2d0278d8788a5db3` (to pull down the image -- that hash matches the commit hash in this PR)
1. `docker images` (to see the current image list -- make note of the image ID for the image above)
1. `docker run -it <image ID> /bin/bash` (to run an interactive shell with that image)
1. While in the interactive shell, do a `go version` and verify that it says `1.16.6`
1. `exit` to get out of the interactive shell

## Changelog or Releases

Go 1.16.x version history:
https://golang.org/doc/devel/release.html#go1.16
