### PR TITLE
[MB-8517] update atlantis base image to 0.17.2 for tf1 upgrade

### DIFF
--- a/milmove-atlantis/Dockerfile
+++ b/milmove-atlantis/Dockerfile
@@ -1,4 +1,4 @@
-FROM runatlantis/atlantis:v0.17.0
+FROM runatlantis/atlantis:v0.17.2
 # This image installs this ^----- particular version of atlantis
 # at /usr/local/bin/atlantis and several versions of terraform.
 # See: https://github.com/runatlantis/atlantis/releases and


### PR DESCRIPTION
Update atlantis base image in dockerfile to version that supports terraform 1.0

- [atl🍑ntis](https://github.com/runatlantis/atlantis/releases)
