### PR TITLE
Revert "Bump cypress from 8.5.0 to 8.6.0 in /milmove-cypress"

### DIFF
--- a/milmove-cypress/package.json
+++ b/milmove-cypress/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.1.0",
   "devDependencies": {
-    "cypress": "^8.6.0",
+    "cypress": "^8.5.0",
     "cypress-audit": "^1.1.0",
     "cypress-multi-reporters": "^1.2.3",
     "cypress-wait-until": "^1.7.1",

--- a/milmove-cypress/yarn.lock
+++ b/milmove-cypress/yarn.lock
@@ -586,10 +586,10 @@ cypress-wait-until@^1.7.1:
   resolved "https://registry.yarnpkg.com/cypress-wait-until/-/cypress-wait-until-1.7.1.tgz#3789cd18affdbb848e3cfc1f918353c7ba1de6f8"
   integrity sha512-8DL5IsBTbAxBjfYgCzdbohPq/bY+IKc63fxtso1C8RWhLnQkZbVESyaclNr76jyxfId6uyzX8+Xnt0ZwaXNtkA==
 
-cypress@^8.6.0:
-  version "8.6.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-8.6.0.tgz#8d02fa58878b37cfc45bbfce393aa974fa8a8e22"
-  integrity sha512-F7qEK/6Go5FsqTueR+0wEw2vOVKNgk5847Mys8vsWkzPoEKdxs+7N9Y1dit+zhaZCLtMPyrMwjfA53ZFy+lSww==
+cypress@^8.5.0:
+  version "8.5.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-8.5.0.tgz#5712ca170913f8344bf167301205c4217c1eb9bd"
+  integrity sha512-MMkXIS+Ro2KETn4gAlG3tIc/7FiljuuCZP0zpd9QsRG6MZSyZW/l1J3D4iQM6WHsVxuX4rFChn5jPFlC2tNSvQ==
   dependencies:
     "@cypress/request" "^2.88.6"
     "@cypress/xvfb" "^1.2.4"


### PR DESCRIPTION
Reverts transcom/circleci-docker#165

We're having unexpected issues with cypress 8.6.0 not passing integration tests, being slow, and showing some odd errors (e.g., "Failed to connect to the bus") that we didn't have with 8.5.0.  I noticed that [8.6.0 includes](https://github.com/cypress-io/cypress/releases/tag/v8.6.0) an update to the Chromium browser as well as electron, so perhaps that's related.  Reverting the 8.6.0 upgrade and will try to debug this from a branch.
