### PR TITLE
[MB-9715] Upgrade golang to 1.17.2

### DIFF
--- a/milmove-app/Dockerfile
+++ b/milmove-app/Dockerfile
@@ -11,8 +11,8 @@ USER root
 ENV GOFLAGS=-p=4
 
 # install go
-ARG GO_VERSION=1.17.1
-ARG GO_SHA256SUM=dab7d9c34361dc21ec237d584590d72500652e7c909bf082758fb63064fca0ef
+ARG GO_VERSION=1.17.2
+ARG GO_SHA256SUM=f242a9db6a0ad1846de7b6d94d507915d14062660616a61ef7c808a76e4f1676
 RUN set -ex && cd ~ \
   && curl -sSLO https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz \
   && [ $(sha256sum go${GO_VERSION}.linux-amd64.tar.gz | cut -f1 -d' ') = ${GO_SHA256SUM} ] \


### PR DESCRIPTION
# Description

Update go from 1.17.1 to 1.17.2 in our docker images in anticipation of switching to Go 1.17.2 in milmove. This includes security fixes released in 1.17.2.

To verify that go 1.17.2 is in the container, do the following:

1. `docker pull milmove/circleci-docker:milmove-app-96cac8d8f0103661fc405481147429ddd7432c0d` (to pull down the image -- that hash matches the commit hash in this PR)
1. `docker images` (to see the current image list -- make note of the image ID for the image above)
1. `docker run -it <image ID> /bin/bash` (to run an interactive shell with that image)
1. While in the interactive shell, do a `go version` and verify that it says `1.17.2`
1. `exit` to get out of the interactive shell

## Changelog or Releases

Go 1.17.x version history:
https://golang.org/doc/devel/release.html#go1.17

## Reviewer Notes

I plan to test the milmove PR using this branch and only merge this PR once everything passes and seems OK.  I'll then update the new `master` hash in the milmove PR.
