### PR TITLE
Pin Node to a specific version

### DIFF
--- a/milmove-app/Dockerfile
+++ b/milmove-app/Dockerfile
@@ -52,7 +52,6 @@ RUN set -ex && cd ~ \
 # Notes:
 # - When adding apt sources do it before 'apt-get update'
 ARG CACHE_APT
-ARG NODE_VERSION=14.17.1
 RUN set -ex && cd ~ \
   && : Remove existing node \
   && rm -rf /usr/local/bin/node /usr/local/bin/nodejs \
@@ -61,7 +60,7 @@ RUN set -ex && cd ~ \
   # See https://github.com/nodesource/distributions/issues/33
   # See https://deb.nodesource.com/node_14.x/pool/main/n/nodejs/ for list of packages
   && curl -sS https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - \
-  && curl -o nodejs.deb https://deb.nodesource.com/node_14.x/pool/main/n/nodejs/nodejs_${NODE_VERSION}-1nodesource1_amd64.deb \
+  && curl -o nodejs.deb https://deb.nodesource.com/node_14.x/pool/main/n/nodejs/nodejs_14.17.1-1nodesource1_amd64.deb \
   && dpkg -i ./nodejs.deb \
   && rm nodejs.deb \
   && : Add Yarn \


### PR DESCRIPTION
# Description

**Why**: The mymove repo uses a specific version of Node, as specified
in the `.node-version` file. The mymove repo also has a
`check-node-version` script that ensures that the local environment has
that specific version installed. Previously, that script was more lax
than it should be. It allowed any 14.x version, but now we updated it
to check for the exact version. This ensures all developers are all
using the same version and eliminates any issues that might arise from
version mismatches.

Similarly, we want all Docker images and the deployed environments to
use the exact same version of Node. Previously, this Docker image was
grabbing the latest 14.x Node version whenever the image was updated,
which caused it to be ahead of the version used in the mymove repo.

This PR now installs a specific Node version. As of today, it's 14.17.1.
If we decide to update the mymove repo in the future, we'll need to
update this image with that same version.
