### PR TITLE
Remove node gpg key command

### DIFF
--- a/milmove-app/Dockerfile
+++ b/milmove-app/Dockerfile
@@ -59,7 +59,6 @@ RUN set -ex && cd ~ \
   # This is so we can pin to specific Node versions
   # See https://github.com/nodesource/distributions/issues/33
   # See https://deb.nodesource.com/node_14.x/pool/main/n/nodejs/ for list of packages
-  && curl -sS https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - \
   && curl -o nodejs.deb https://deb.nodesource.com/node_14.x/pool/main/n/nodejs/nodejs_14.17.1-1nodesource1_amd64.deb \
   && dpkg -i ./nodejs.deb \
   && rm nodejs.deb \


### PR DESCRIPTION
# Description

I wonder if this is what is causing the build failures. It passed in
PR #169, but then all subsequent builds on master failed.

Example: https://app.circleci.com/pipelines/github/transcom/circleci-docker/521/workflows/0346abd3-86a8-4c7e-b584-a6a7a93192ba/jobs/575
