### PR TITLE
[MB-11440] tfsec updater

### DIFF
--- a/.github/workflows/tfsec.yml
+++ b/.github/workflows/tfsec.yml
@@ -2,7 +2,7 @@ name: Get latest tfsec version
 
 on:
   schedule: 
-    - cron: '21 40 * * *'
+    - cron: '40 21 * * *'
 
 jobs:
   update-tfsec:

--- a/.github/workflows/tfsec.yml
+++ b/.github/workflows/tfsec.yml
@@ -23,3 +23,11 @@ jobs:
         run: |
           echo $OLD_VERSION
           echo $NEW_VERSION
+      - name: Change release version in Dockerfile
+        if: ${{ steps.get-versions.outputs.release_tag != steps.get-versions.outputs.current_tag }}
+        id: update-version
+        env:
+          OLD_VERSION: ${{ steps.get-versions.outputs.current_tag }}
+          NEW_VERSION: ${{ steps.get-versions.outputs.release_tag }}
+        run: |
+          sed -i --expression='s,$OLD_VERSION,$NEW_VERSION,g' $CURRENT_IMAGE_DIRECTORY/Dockerfile

--- a/.github/workflows/tfsec.yml
+++ b/.github/workflows/tfsec.yml
@@ -27,6 +27,7 @@ jobs:
         run: |
           echo $OLD_VERSION
           echo $NEW_VERSION
+          cd ${CURRENT_IMAGE_DIRECTORY}
           sed -i --expression='s,${OLD_VERSION},${NEW_VERSION},g' "${CURRENT_IMAGE_DIRECTORY}/Dockerfile"
       - name: set up Git
         if: ${{ steps.get-versions.outputs.release_tag != steps.get-versions.outputs.current_tag }}

--- a/.github/workflows/tfsec.yml
+++ b/.github/workflows/tfsec.yml
@@ -27,12 +27,12 @@ jobs:
       #   run: |
       #     sed -i --expression='s,"'"$OLD_VERSION"'","'"$NEW_VERSION"'",g' $CURRENT_IMAGE_DIRECTORY/Dockerfile
       - name: trying to test functionality
-          if: ${{ steps.get-versions.outputs.release_tag != steps.get-versions.outputs.current_tag }}
-          env:
-            OLD_VERSION: ${{ steps.get-versions.outputs.current_tag }}
-            NEW_VERSION: ${{ steps.get-versions.outputs.release_tag }}
-          run: |
-            touch testfile.txt
+        if: ${{ steps.get-versions.outputs.release_tag != steps.get-versions.outputs.current_tag }}
+        env:
+          OLD_VERSION: ${{ steps.get-versions.outputs.current_tag }}
+          NEW_VERSION: ${{ steps.get-versions.outputs.release_tag }}
+        run: |
+          touch testfile.txt
       - name: set up Git
         # if: ${{ steps.get-versions.outputs.release_tag != steps.get-versions.outputs.current_tag }}
         env:

--- a/.github/workflows/tfsec.yml
+++ b/.github/workflows/tfsec.yml
@@ -18,14 +18,14 @@ jobs:
         run: |
           echo ::set-output name=current_tag::$(grep TFSEC_VERSION $CURRENT_IMAGE_DIRECTORY/Dockerfile | head -1 | cut -d'=' -f 2)
           echo ::set-output name=release_tag::$(curl -sL https://api.github.com/repos/aquasecurity/tfsec/releases/latest | jq -r ".tag_name[1:]")
-      - name: Get sha256sum if applicable
+      - name: Get sha256sum
         if: ${{ steps.get-versions.outputs.release_tag != steps.get-versions.outputs.current_tag }}
         id: checksum
         env:
           NEW_VERSION: ${{ steps.get-versions.outputs.release_tag }}
         run: |
-          curl -sL https://github.com/aquasecurity/tfsec/releases/download/v${NEW_VERSION}/tfsec-linux-amd64
-          sha256sum tfsec-linux-amd64
+          curl -sL https://github.com/aquasecurity/tfsec/releases/download/v${NEW_VERSION}/tfsec-linux-amd64 --output "shafile"
+          echo ::set-output name=new_sha256sum::$(sha256sum shafile | cut -d' ' -f 1)
       - name: Change release version in Dockerfile
         if: ${{ steps.get-versions.outputs.release_tag != steps.get-versions.outputs.current_tag }}
         id: update-version

--- a/.github/workflows/tfsec.yml
+++ b/.github/workflows/tfsec.yml
@@ -2,7 +2,7 @@ name: Get latest tfsec version
 
 on:
   schedule: 
-    - cron: '13 00 * * *'
+    - cron: '21 40 * * *'
 
 jobs:
   update-tfsec:

--- a/.github/workflows/tfsec.yml
+++ b/.github/workflows/tfsec.yml
@@ -1,8 +1,8 @@
 name: Get latest tfsec version
 
-on: push
-  # schedule: 
-  #   - cron: '13 00 * * *'
+on:
+  schedule: 
+    - cron: '13 00 * * *'
 
 jobs:
   update-tfsec:
@@ -54,7 +54,7 @@ jobs:
           token: ${{ secrets.ROBOT_MYMOVE_TOKEN }}
           commit-message: Update tfsec to new version
           author: ${GITHUB_ACTOR_NAME} <${GITHUB_ACTOR_EMAIL}>
-          branch: test-the-team-function-tfsec-update-${{ steps.get-versions.outputs.release_tag }}
+          branch: tfsec-update-${{ steps.get-versions.outputs.release_tag }}
           delete-branch: true
           title: Update tfsec Version to ${{ steps.get-versions.outputs.release_tag }}
           body: |

--- a/.github/workflows/tfsec.yml
+++ b/.github/workflows/tfsec.yml
@@ -1,8 +1,8 @@
 name: Get latest tfsec version
 
 on:
-  push:
-    branches: [master,  mb-11440-tfsec-updater]
+  schedule: 
+    - cron: '20 30 * * *'
 
 jobs:
   update-tfsec:
@@ -42,7 +42,7 @@ jobs:
           token: ${{ secrets.ROBOT_MYMOVE_TOKEN }}
           commit-message: Update tfsec to new version
           author: ${GITHUB_ACTOR_NAME} <${GITHUB_ACTOR_EMAIL}>
-          branch: ranfawiefhewadombranchfaweoijname-${{ steps.get-versions.outputs.release_tag }}
+          branch: new-tfsec-version-${{ steps.get-versions.outputs.release_tag }}
           delete-branch: true
           title: Update tfsec Version to ${{ steps.get-versions.outputs.release_tag }}
           body: |

--- a/.github/workflows/tfsec.yml
+++ b/.github/workflows/tfsec.yml
@@ -28,7 +28,7 @@ jobs:
           echo $OLD_VERSION
           echo $NEW_VERSION
           cd ${CURRENT_IMAGE_DIRECTORY}
-          sed -i --expression='s,${OLD_VERSION},${NEW_VERSION},g' Dockerfile
+          sed -i --expression='s,"TFSEC_VERSION=${OLD_VERSION}","TFSEC_VERSION=${NEW_VERSION}",g' Dockerfile
       - name: set up Git
         if: ${{ steps.get-versions.outputs.release_tag != steps.get-versions.outputs.current_tag }}
         env:

--- a/.github/workflows/tfsec.yml
+++ b/.github/workflows/tfsec.yml
@@ -1,6 +1,8 @@
 name: Get latest tfsec version
 
-on: [push]
+on:
+  push:
+    branches: [master,  mb-11440-tfsec-updater]
 
 jobs:
   update-tfsec:
@@ -16,13 +18,6 @@ jobs:
         run: |
           echo ::set-output name=current_tag::$(grep TFSEC_VERSION $CURRENT_IMAGE_DIRECTORY/Dockerfile | head -1 | cut -d'=' -f 2)
           echo ::set-output name=release_tag::$(curl -sL https://api.github.com/repos/aquasecurity/tfsec/releases/latest | jq -r ".tag_name[1:] | tostring")
-      - name: Test echo
-        env:
-          OLD_VERSION: ${{ steps.get-versions.outputs.current_tag }}
-          NEW_VERSION: ${{ steps.get-versions.outputs.release_tag }}
-        run: |
-          echo $OLD_VERSION
-          echo $NEW_VERSION
       - name: Change release version in Dockerfile
         if: ${{ steps.get-versions.outputs.release_tag != steps.get-versions.outputs.current_tag }}
         id: update-version

--- a/.github/workflows/tfsec.yml
+++ b/.github/workflows/tfsec.yml
@@ -28,7 +28,7 @@ jobs:
           echo $OLD_VERSION
           echo $NEW_VERSION
           cd ${CURRENT_IMAGE_DIRECTORY}
-          sed -i --expression='s,${OLD_VERSION},${NEW_VERSION},g' "${CURRENT_IMAGE_DIRECTORY}/Dockerfile"
+          sed -i --expression='s,${OLD_VERSION},${NEW_VERSION},g' Dockerfile
       - name: set up Git
         if: ${{ steps.get-versions.outputs.release_tag != steps.get-versions.outputs.current_tag }}
         env:

--- a/.github/workflows/tfsec.yml
+++ b/.github/workflows/tfsec.yml
@@ -28,7 +28,7 @@ jobs:
           echo $OLD_VERSION
           echo $NEW_VERSION
           cd ${CURRENT_IMAGE_DIRECTORY}
-          sed -i --expression='s,"TFSEC_VERSION=${OLD_VERSION}","TFSEC_VERSION=${NEW_VERSION}",g' Dockerfile
+          sed -i --expression="s/TFSEC_VERSION=$OLD_VERSION/TFSEC_VERSION=$NEW_VERSION" Dockerfile
       - name: set up Git
         if: ${{ steps.get-versions.outputs.release_tag != steps.get-versions.outputs.current_tag }}
         env:

--- a/.github/workflows/tfsec.yml
+++ b/.github/workflows/tfsec.yml
@@ -26,7 +26,7 @@ jobs:
           NEW_VERSION: ${{ steps.get-versions.outputs.release_tag }}
         run: |
           cd $CURRENT_IMAGE_DIRECTORY
-          sed -i --expression='s,"$OLD_VERSION","$NEW_VERSION",g' Dockerfile
+          sed -i --expression='s,$OLD_VERSION,$NEW_VERSION,g' Dockerfile
       - name: set up Git
         if: ${{ steps.get-versions.outputs.release_tag != steps.get-versions.outputs.current_tag }}
         env:

--- a/.github/workflows/tfsec.yml
+++ b/.github/workflows/tfsec.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.ROBOT_MYMOVE_TOKEN }}
       - name: Set release version and current version variables
         id: get-versions
         run: |
@@ -31,3 +31,25 @@ jobs:
           NEW_VERSION: ${{ steps.get-versions.outputs.release_tag }}
         run: |
           sed -i --expression='s,$OLD_VERSION,$NEW_VERSION,g' $CURRENT_IMAGE_DIRECTORY/Dockerfile
+      - name: set up Git
+        if: ${{ steps.get-versions.outputs.release_tag != steps.get-versions.outputs.current_tag }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.ROBOT_MYMOVE_TOKEN }}
+          GITHUB_ACTOR_NAME: "robot-mymove"
+          GITHUB_ACTOR_EMAIL: "dp3-integrations+github@truss.works"
+        run: |
+          git config --global user.name "${GITHUB_ACTOR_NAME}"
+          git config --global user.email "${GITHUB_ACTOR_EMAIL}"
+      - name: Create Pull Request
+        if: ${{ steps.get-versions.outputs.release_tag != steps.get-versions.outputs.current_tag }}
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ secrets.ROBOT_MYMOVE_TOKEN }}
+          commit-message: Update tfsec to new version
+          author: ${GITHUB_ACTOR_NAME} <${GITHUB_ACTOR_EMAIL}>
+          branch: automatic-update-tfsec-${{ steps.get-versions.outputs.release_tag }}
+          delete-branch: true
+          title: Update tfsec Version to ${{ steps.get-versions.outputs.release_tag }}
+          body: |
+            Automated update from tfsec version ${{ steps.get-versions.outputs.current_tag }} to version ${{ steps.get-versions.outputs.release_tag }}
+            Release Notes: https://github.com/aquasecurity/tfsec/releases/tag/v${{ steps.get-versions.outputs.release_tag }}

--- a/.github/workflows/tfsec.yml
+++ b/.github/workflows/tfsec.yml
@@ -25,10 +25,7 @@ jobs:
           OLD_VERSION: ${{ steps.get-versions.outputs.current_tag }}
           NEW_VERSION: ${{ steps.get-versions.outputs.release_tag }}
         run: |
-          echo $OLD_VERSION
-          echo $NEW_VERSION
-          cd ${CURRENT_IMAGE_DIRECTORY}
-          sed -i --expression="s/$OLD_VERSION/$NEW_VERSION/" Dockerfile
+          sed -i --expression="s/$OLD_VERSION/$NEW_VERSION/" $CURRENT_IMAGE_DIRECTORY/Dockerfile
       - name: set up Git
         if: ${{ steps.get-versions.outputs.release_tag != steps.get-versions.outputs.current_tag }}
         env:
@@ -45,7 +42,7 @@ jobs:
           token: ${{ secrets.ROBOT_MYMOVE_TOKEN }}
           commit-message: Update tfsec to new version
           author: ${GITHUB_ACTOR_NAME} <${GITHUB_ACTOR_EMAIL}>
-          branch: randombranchfaweoijname-${{ steps.get-versions.outputs.release_tag }}
+          branch: ranfawiefhewadombranchfaweoijname-${{ steps.get-versions.outputs.release_tag }}
           delete-branch: true
           title: Update tfsec Version to ${{ steps.get-versions.outputs.release_tag }}
           body: |

--- a/.github/workflows/tfsec.yml
+++ b/.github/workflows/tfsec.yml
@@ -24,7 +24,7 @@ jobs:
         env:
           NEW_VERSION: ${{ steps.get-versions.outputs.release_tag }}
         run: |
-          curl -sL https://github.com/aquasecurity/tfsec/releases/download/$NEW_VERSION/tfsec-linux-amd64
+          curl -sL https://github.com/aquasecurity/tfsec/releases/download/v${NEW_VERSION}/tfsec-linux-amd64
           sha256sum tfsec-linux-amd64
       - name: Change release version in Dockerfile
         if: ${{ steps.get-versions.outputs.release_tag != steps.get-versions.outputs.current_tag }}

--- a/.github/workflows/tfsec.yml
+++ b/.github/workflows/tfsec.yml
@@ -25,8 +25,7 @@ jobs:
           OLD_VERSION: ${{ steps.get-versions.outputs.current_tag }}
           NEW_VERSION: ${{ steps.get-versions.outputs.release_tag }}
         run: |
-          cd $CURRENT_IMAGE_DIRECTORY
-          sed -i --expression='s,$OLD_VERSION,$NEW_VERSION,g' Dockerfile
+          sed -i --expression='s,${OLD_VERSION},${NEW_VERSION},g' "${CURRENT_IMAGE_DIRECTORY}/Dockerfile"
       - name: set up Git
         if: ${{ steps.get-versions.outputs.release_tag != steps.get-versions.outputs.current_tag }}
         env:

--- a/.github/workflows/tfsec.yml
+++ b/.github/workflows/tfsec.yml
@@ -17,17 +17,24 @@ jobs:
         id: get-versions
         run: |
           echo ::set-output name=current_tag::$(grep TFSEC_VERSION $CURRENT_IMAGE_DIRECTORY/Dockerfile | head -1 | cut -d'=' -f 2)
-          echo ::set-output name=release_tag::$(curl -sL https://api.github.com/repos/aquasecurity/tfsec/releases/latest | jq -r ".tag_name[1:] | tostring")
-      - name: Change release version in Dockerfile
-        if: ${{ steps.get-versions.outputs.release_tag != steps.get-versions.outputs.current_tag }}
-        id: update-version
-        env:
-          OLD_VERSION: ${{ steps.get-versions.outputs.current_tag }}
-          NEW_VERSION: ${{ steps.get-versions.outputs.release_tag }}
-        run: |
-          sed -i --expression='s,$OLD_VERSION,$NEW_VERSION,g' $CURRENT_IMAGE_DIRECTORY/Dockerfile
+          echo ::set-output name=release_tag::$(curl -sL https://api.github.com/repos/aquasecurity/tfsec/releases/latest | jq -r ".tag_name[1:]")
+      # - name: Change release version in Dockerfile
+      #   if: ${{ steps.get-versions.outputs.release_tag != steps.get-versions.outputs.current_tag }}
+      #   id: update-version
+      #   env:
+      #     OLD_VERSION: ${{ steps.get-versions.outputs.current_tag }}
+      #     NEW_VERSION: ${{ steps.get-versions.outputs.release_tag }}
+      #   run: |
+      #     sed -i --expression='s,"'"$OLD_VERSION"'","'"$NEW_VERSION"'",g' $CURRENT_IMAGE_DIRECTORY/Dockerfile
+      - name: trying to test functionality
+          if: ${{ steps.get-versions.outputs.release_tag != steps.get-versions.outputs.current_tag }}
+          env:
+            OLD_VERSION: ${{ steps.get-versions.outputs.current_tag }}
+            NEW_VERSION: ${{ steps.get-versions.outputs.release_tag }}
+          run: |
+            touch testfile.txt
       - name: set up Git
-        if: ${{ steps.get-versions.outputs.release_tag != steps.get-versions.outputs.current_tag }}
+        # if: ${{ steps.get-versions.outputs.release_tag != steps.get-versions.outputs.current_tag }}
         env:
           GITHUB_TOKEN: ${{ secrets.ROBOT_MYMOVE_TOKEN }}
           GITHUB_ACTOR_NAME: "robot-mymove"
@@ -36,7 +43,7 @@ jobs:
           git config --global user.name "${GITHUB_ACTOR_NAME}"
           git config --global user.email "${GITHUB_ACTOR_EMAIL}"
       - name: Create Pull Request
-        if: ${{ steps.get-versions.outputs.release_tag != steps.get-versions.outputs.current_tag }}
+        # if: ${{ steps.get-versions.outputs.release_tag != steps.get-versions.outputs.current_tag }}
         uses: peter-evans/create-pull-request@v3
         with:
           token: ${{ secrets.ROBOT_MYMOVE_TOKEN }}

--- a/.github/workflows/tfsec.yml
+++ b/.github/workflows/tfsec.yml
@@ -14,8 +14,12 @@ jobs:
       - name: Set release version and current version variables
         id: get-versions
         run: |
-          echo ::set-output name=current_tag::$(grep TFSEC_VERSION $CURRENT_IMAGE_DIRECTORY/Dockerfile | cut -d'=' -f 2 | sed -e 's/^"//' -e 's/"$//')
+          echo ::set-output name=current_tag::$(grep TFSEC_VERSION $CURRENT_IMAGE_DIRECTORY/Dockerfile | head -1 | cut -d'=' -f 2)
+          echo ::set-output name=release_tag::$(curl -sL https://api.github.com/repos/aquasecurity/tfsec/releases/latest | jq -r ".tag_name[1:] | tostring")
       - name: Test echo
         env:
           OLD_VERSION: ${{ steps.get-versions.outputs.current_tag }}
-        run: echo $OLD_VERSION
+          NEW_VERSION: ${{ steps.get-versions.outputs.release_tag }}
+        run: |
+          echo $OLD_VERSION
+          echo $NEW_VERSION

--- a/.github/workflows/tfsec.yml
+++ b/.github/workflows/tfsec.yml
@@ -24,9 +24,13 @@ jobs:
         env:
           NEW_VERSION: ${{ steps.get-versions.outputs.release_tag }}
         run: |
+          echo ::set-output name=current_sha256sum::$(grep TFSEC_SHA256SUM $CURRENT_IMAGE_DIRECTORY/Dockerfile | head -1 | cut -d'=' -f 2)
           curl -sL https://github.com/aquasecurity/tfsec/releases/download/v${NEW_VERSION}/tfsec-linux-amd64 --output "shafile"
-          echo ::set-output name=new_sha256sum::$(sha256sum shafile | cut -d' ' -f 1)
-      - run: echo ${{ steps.checksum.outputs.new_sha256sum }}
+          echo ::set-output name=release_sha256sum::$(sha256sum shafile | cut -d' ' -f 1)
+      - name: check the sums are right
+        run: |
+          echo ${{ steps.checksum.outputs.current_sha256sum }}
+          echo ${{ steps.checksum.outputs.release_sha256sum }}
       - name: Change release version in Dockerfile
         if: ${{ steps.get-versions.outputs.release_tag != steps.get-versions.outputs.current_tag }}
         id: update-version

--- a/.github/workflows/tfsec.yml
+++ b/.github/workflows/tfsec.yml
@@ -17,22 +17,16 @@ jobs:
         id: get-versions
         run: |
           echo ::set-output name=current_tag::$(grep TFSEC_VERSION $CURRENT_IMAGE_DIRECTORY/Dockerfile | head -1 | cut -d'=' -f 2)
-          echo ::set-output name=release_tag::$(curl -sL https://api.github.com/repos/aquasecurity/tfsec/releases/latest | jq -r ".tag_name[1:]")
-      # - name: Change release version in Dockerfile
-      #   if: ${{ steps.get-versions.outputs.release_tag != steps.get-versions.outputs.current_tag }}
-      #   id: update-version
-      #   env:
-      #     OLD_VERSION: ${{ steps.get-versions.outputs.current_tag }}
-      #     NEW_VERSION: ${{ steps.get-versions.outputs.release_tag }}
-      #   run: |
-      #     sed -i --expression='s,"'"$OLD_VERSION"'","'"$NEW_VERSION"'",g' $CURRENT_IMAGE_DIRECTORY/Dockerfile
-      - name: trying to test functionality
+          echo ::set-output name=release_tag::$(curl -sL https://api.github.com/repos/aquasecurity/tfsec/releases/latest | jq -r ".tag_name[1:] | tostring")
+      - name: Change release version in Dockerfile
         if: ${{ steps.get-versions.outputs.release_tag != steps.get-versions.outputs.current_tag }}
+        id: update-version
         env:
           OLD_VERSION: ${{ steps.get-versions.outputs.current_tag }}
           NEW_VERSION: ${{ steps.get-versions.outputs.release_tag }}
         run: |
-          touch testfile.txt
+          cd $CURRENT_IMAGE_DIRECTORY
+          sed -i --expression='s,"$OLD_VERSION","$NEW_VERSION",g' Dockerfile
       - name: set up Git
         if: ${{ steps.get-versions.outputs.release_tag != steps.get-versions.outputs.current_tag }}
         env:
@@ -49,7 +43,7 @@ jobs:
           token: ${{ secrets.ROBOT_MYMOVE_TOKEN }}
           commit-message: Update tfsec to new version
           author: ${GITHUB_ACTOR_NAME} <${GITHUB_ACTOR_EMAIL}>
-          branch: somethingelse-tfsec-${{ steps.get-versions.outputs.release_tag }}
+          branch: randombranchname-${{ steps.get-versions.outputs.release_tag }}
           delete-branch: true
           title: Update tfsec Version to ${{ steps.get-versions.outputs.release_tag }}
           body: |

--- a/.github/workflows/tfsec.yml
+++ b/.github/workflows/tfsec.yml
@@ -1,0 +1,21 @@
+name: Get latest tfsec version
+
+on: [push]
+
+jobs:
+  update-tfsec:
+    runs-on: ubuntu-latest
+    env:
+      CURRENT_IMAGE_DIRECTORY: 'milmove-infra-tf112'
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set release version and current version variables
+        id: get-versions
+        run: |
+          echo ::set-output name=current_tag::$(grep TFSEC_VERSION ${{ CURRENT_IMAGE_DIRECTORY }}/Dockerfile | cut -d'=' -f 2 | sed -e 's/^"//' -e 's/"$//')
+      - name: Test echo
+        env:
+          OLD_VERSION: ${{ steps.get-versions.outputs.current_tag }}
+        run: echo $OLD_VERSION

--- a/.github/workflows/tfsec.yml
+++ b/.github/workflows/tfsec.yml
@@ -25,7 +25,9 @@ jobs:
           OLD_VERSION: ${{ steps.get-versions.outputs.current_tag }}
           NEW_VERSION: ${{ steps.get-versions.outputs.release_tag }}
         run: |
-          sed -i --expression='s,${OLD_VERSION},${NEW_VERSION},g' "${CURRENT_IMAGE_DIRECTORY}/Dockerfile"
+        echo $OLD_VERSION
+        echo $NEW_VERSION
+        sed -i --expression='s,${OLD_VERSION},${NEW_VERSION},g' "${CURRENT_IMAGE_DIRECTORY}/Dockerfile"
       - name: set up Git
         if: ${{ steps.get-versions.outputs.release_tag != steps.get-versions.outputs.current_tag }}
         env:

--- a/.github/workflows/tfsec.yml
+++ b/.github/workflows/tfsec.yml
@@ -1,8 +1,8 @@
 name: Get latest tfsec version
 
-on:
-  schedule: 
-    - cron: '13 00 * * *'
+on: push
+  # schedule: 
+  #   - cron: '13 00 * * *'
 
 jobs:
   update-tfsec:
@@ -54,9 +54,10 @@ jobs:
           token: ${{ secrets.ROBOT_MYMOVE_TOKEN }}
           commit-message: Update tfsec to new version
           author: ${GITHUB_ACTOR_NAME} <${GITHUB_ACTOR_EMAIL}>
-          branch: tfsec-update-${{ steps.get-versions.outputs.release_tag }}
+          branch: test-the-team-function-tfsec-update-${{ steps.get-versions.outputs.release_tag }}
           delete-branch: true
           title: Update tfsec Version to ${{ steps.get-versions.outputs.release_tag }}
           body: |
             Automated update from tfsec version ${{ steps.get-versions.outputs.current_tag }} to version ${{ steps.get-versions.outputs.release_tag }}
             Release Notes: https://github.com/aquasecurity/tfsec/releases/tag/v${{ steps.get-versions.outputs.release_tag }}
+          team-reviewers: Truss-InfraSec

--- a/.github/workflows/tfsec.yml
+++ b/.github/workflows/tfsec.yml
@@ -17,7 +17,7 @@ jobs:
         id: get-versions
         run: |
           echo ::set-output name=current_tag::$(grep TFSEC_VERSION $CURRENT_IMAGE_DIRECTORY/Dockerfile | head -1 | cut -d'=' -f 2)
-          echo ::set-output name=release_tag::$(curl -sL https://api.github.com/repos/aquasecurity/tfsec/releases/latest | jq -r ".tag_name[1:] | tostring")
+          echo ::set-output name=release_tag::$(curl -sL https://api.github.com/repos/aquasecurity/tfsec/releases/latest | jq -r ".tag_name[1:]")
       - name: Change release version in Dockerfile
         if: ${{ steps.get-versions.outputs.release_tag != steps.get-versions.outputs.current_tag }}
         id: update-version

--- a/.github/workflows/tfsec.yml
+++ b/.github/workflows/tfsec.yml
@@ -27,18 +27,17 @@ jobs:
           echo ::set-output name=current_sha256sum::$(grep TFSEC_SHA256SUM $CURRENT_IMAGE_DIRECTORY/Dockerfile | head -1 | cut -d'=' -f 2)
           curl -sL https://github.com/aquasecurity/tfsec/releases/download/v${NEW_VERSION}/tfsec-linux-amd64 --output "shafile"
           echo ::set-output name=release_sha256sum::$(sha256sum shafile | cut -d' ' -f 1)
-      - name: check the sums are right
-        run: |
-          echo ${{ steps.checksum.outputs.current_sha256sum }}
-          echo ${{ steps.checksum.outputs.release_sha256sum }}
       - name: Change release version in Dockerfile
         if: ${{ steps.get-versions.outputs.release_tag != steps.get-versions.outputs.current_tag }}
         id: update-version
         env:
           OLD_VERSION: ${{ steps.get-versions.outputs.current_tag }}
           NEW_VERSION: ${{ steps.get-versions.outputs.release_tag }}
+          OLD_SHA256SUM: ${{ steps.checksum.outputs.current_sha256sum }}
+          NEW_SHA256SUM: ${{ steps.checksum.outputs.release_sha256sum }}
         run: |
           sed -i --expression="s/$OLD_VERSION/$NEW_VERSION/" $CURRENT_IMAGE_DIRECTORY/Dockerfile
+          sed -i --expression="s/$OLD_SHA256SUM/$NEW_SHA256SUM/" $CURRENT_IMAGE_DIRECTORY/Dockerfile
       - name: set up Git
         if: ${{ steps.get-versions.outputs.release_tag != steps.get-versions.outputs.current_tag }}
         env:
@@ -55,7 +54,7 @@ jobs:
           token: ${{ secrets.ROBOT_MYMOVE_TOKEN }}
           commit-message: Update tfsec to new version
           author: ${GITHUB_ACTOR_NAME} <${GITHUB_ACTOR_EMAIL}>
-          branch: seeifwecangetsha-${{ steps.get-versions.outputs.release_tag }}
+          branch: ithinkthisisit-${{ steps.get-versions.outputs.release_tag }}
           delete-branch: true
           title: Update tfsec Version to ${{ steps.get-versions.outputs.release_tag }}
           body: |

--- a/.github/workflows/tfsec.yml
+++ b/.github/workflows/tfsec.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           touch testfile.txt
       - name: set up Git
-        # if: ${{ steps.get-versions.outputs.release_tag != steps.get-versions.outputs.current_tag }}
+        if: ${{ steps.get-versions.outputs.release_tag != steps.get-versions.outputs.current_tag }}
         env:
           GITHUB_TOKEN: ${{ secrets.ROBOT_MYMOVE_TOKEN }}
           GITHUB_ACTOR_NAME: "robot-mymove"
@@ -43,13 +43,13 @@ jobs:
           git config --global user.name "${GITHUB_ACTOR_NAME}"
           git config --global user.email "${GITHUB_ACTOR_EMAIL}"
       - name: Create Pull Request
-        # if: ${{ steps.get-versions.outputs.release_tag != steps.get-versions.outputs.current_tag }}
+        if: ${{ steps.get-versions.outputs.release_tag != steps.get-versions.outputs.current_tag }}
         uses: peter-evans/create-pull-request@v3
         with:
           token: ${{ secrets.ROBOT_MYMOVE_TOKEN }}
           commit-message: Update tfsec to new version
           author: ${GITHUB_ACTOR_NAME} <${GITHUB_ACTOR_EMAIL}>
-          branch: automatic-update-tfsec-${{ steps.get-versions.outputs.release_tag }}
+          branch: somethingelse-tfsec-${{ steps.get-versions.outputs.release_tag }}
           delete-branch: true
           title: Update tfsec Version to ${{ steps.get-versions.outputs.release_tag }}
           body: |

--- a/.github/workflows/tfsec.yml
+++ b/.github/workflows/tfsec.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set release version and current version variables
         id: get-versions
         run: |
-          echo ::set-output name=current_tag::$(grep TFSEC_VERSION ${{ CURRENT_IMAGE_DIRECTORY }}/Dockerfile | cut -d'=' -f 2 | sed -e 's/^"//' -e 's/"$//')
+          echo ::set-output name=current_tag::$(grep TFSEC_VERSION $CURRENT_IMAGE_DIRECTORY/Dockerfile | cut -d'=' -f 2 | sed -e 's/^"//' -e 's/"$//')
       - name: Test echo
         env:
           OLD_VERSION: ${{ steps.get-versions.outputs.current_tag }}

--- a/.github/workflows/tfsec.yml
+++ b/.github/workflows/tfsec.yml
@@ -28,7 +28,7 @@ jobs:
           echo $OLD_VERSION
           echo $NEW_VERSION
           cd ${CURRENT_IMAGE_DIRECTORY}
-          sed -i --expression="s/TFSEC_VERSION=$OLD_VERSION/TFSEC_VERSION=$NEW_VERSION" Dockerfile
+          sed -i --expression="s/TFSEC_VERSION=$OLD_VERSION/TFSEC_VERSION=$NEW_VERSION/" Dockerfile
       - name: set up Git
         if: ${{ steps.get-versions.outputs.release_tag != steps.get-versions.outputs.current_tag }}
         env:

--- a/.github/workflows/tfsec.yml
+++ b/.github/workflows/tfsec.yml
@@ -25,9 +25,9 @@ jobs:
           OLD_VERSION: ${{ steps.get-versions.outputs.current_tag }}
           NEW_VERSION: ${{ steps.get-versions.outputs.release_tag }}
         run: |
-        echo $OLD_VERSION
-        echo $NEW_VERSION
-        sed -i --expression='s,${OLD_VERSION},${NEW_VERSION},g' "${CURRENT_IMAGE_DIRECTORY}/Dockerfile"
+          echo $OLD_VERSION
+          echo $NEW_VERSION
+          sed -i --expression='s,${OLD_VERSION},${NEW_VERSION},g' "${CURRENT_IMAGE_DIRECTORY}/Dockerfile"
       - name: set up Git
         if: ${{ steps.get-versions.outputs.release_tag != steps.get-versions.outputs.current_tag }}
         env:

--- a/.github/workflows/tfsec.yml
+++ b/.github/workflows/tfsec.yml
@@ -28,7 +28,7 @@ jobs:
           echo $OLD_VERSION
           echo $NEW_VERSION
           cd ${CURRENT_IMAGE_DIRECTORY}
-          sed -i --expression="s/TFSEC_VERSION=$OLD_VERSION/TFSEC_VERSION=$NEW_VERSION/" Dockerfile
+          sed -i --expression="s/$OLD_VERSION/$NEW_VERSION/" Dockerfile
       - name: set up Git
         if: ${{ steps.get-versions.outputs.release_tag != steps.get-versions.outputs.current_tag }}
         env:
@@ -45,7 +45,7 @@ jobs:
           token: ${{ secrets.ROBOT_MYMOVE_TOKEN }}
           commit-message: Update tfsec to new version
           author: ${GITHUB_ACTOR_NAME} <${GITHUB_ACTOR_EMAIL}>
-          branch: randombranchname-${{ steps.get-versions.outputs.release_tag }}
+          branch: randombranchfaweoijname-${{ steps.get-versions.outputs.release_tag }}
           delete-branch: true
           title: Update tfsec Version to ${{ steps.get-versions.outputs.release_tag }}
           body: |

--- a/.github/workflows/tfsec.yml
+++ b/.github/workflows/tfsec.yml
@@ -1,8 +1,8 @@
 name: Get latest tfsec version
 
-on:
-  schedule: 
-    - cron: '20 30 * * *'
+on: push
+  # schedule: 
+  #   - cron: '20 30 * * *'
 
 jobs:
   update-tfsec:
@@ -18,6 +18,14 @@ jobs:
         run: |
           echo ::set-output name=current_tag::$(grep TFSEC_VERSION $CURRENT_IMAGE_DIRECTORY/Dockerfile | head -1 | cut -d'=' -f 2)
           echo ::set-output name=release_tag::$(curl -sL https://api.github.com/repos/aquasecurity/tfsec/releases/latest | jq -r ".tag_name[1:]")
+      - name: Get sha256sum if applicable
+        if: ${{ steps.get-versions.outputs.release_tag != steps.get-versions.outputs.current_tag }}
+        id: checksum
+        env:
+          NEW_VERSION: ${{ steps.get-versions.outputs.release_tag }}
+        run: |
+          curl -sL https://github.com/aquasecurity/tfsec/releases/download/$NEW_VERSION/tfsec-linux-amd64
+          sha256sum tfsec-linux-amd64
       - name: Change release version in Dockerfile
         if: ${{ steps.get-versions.outputs.release_tag != steps.get-versions.outputs.current_tag }}
         id: update-version
@@ -42,7 +50,7 @@ jobs:
           token: ${{ secrets.ROBOT_MYMOVE_TOKEN }}
           commit-message: Update tfsec to new version
           author: ${GITHUB_ACTOR_NAME} <${GITHUB_ACTOR_EMAIL}>
-          branch: new-tfsec-version-${{ steps.get-versions.outputs.release_tag }}
+          branch: seeifwecangetsha-${{ steps.get-versions.outputs.release_tag }}
           delete-branch: true
           title: Update tfsec Version to ${{ steps.get-versions.outputs.release_tag }}
           body: |

--- a/.github/workflows/tfsec.yml
+++ b/.github/workflows/tfsec.yml
@@ -26,6 +26,7 @@ jobs:
         run: |
           curl -sL https://github.com/aquasecurity/tfsec/releases/download/v${NEW_VERSION}/tfsec-linux-amd64 --output "shafile"
           echo ::set-output name=new_sha256sum::$(sha256sum shafile | cut -d' ' -f 1)
+      - run: echo ${{ steps.checksum.outputs.new_sha256sum }}
       - name: Change release version in Dockerfile
         if: ${{ steps.get-versions.outputs.release_tag != steps.get-versions.outputs.current_tag }}
         id: update-version

--- a/.github/workflows/tfsec.yml
+++ b/.github/workflows/tfsec.yml
@@ -1,8 +1,8 @@
 name: Get latest tfsec version
 
-on: push
-  # schedule: 
-  #   - cron: '20 30 * * *'
+on:
+  schedule: 
+    - cron: '13 00 * * *'
 
 jobs:
   update-tfsec:
@@ -54,7 +54,7 @@ jobs:
           token: ${{ secrets.ROBOT_MYMOVE_TOKEN }}
           commit-message: Update tfsec to new version
           author: ${GITHUB_ACTOR_NAME} <${GITHUB_ACTOR_EMAIL}>
-          branch: ithinkthisisit-${{ steps.get-versions.outputs.release_tag }}
+          branch: tfsec-update-${{ steps.get-versions.outputs.release_tag }}
           delete-branch: true
           title: Update tfsec Version to ${{ steps.get-versions.outputs.release_tag }}
           body: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode/*
 *node_modules/
+shafile


### PR DESCRIPTION
# Description

This PR adds a GitHub action to check for updates to tfsec every morning at 8AM. If there is a new release available, the workflow will automatically create a PR such as this one: https://github.com/transcom/circleci-docker/pull/200

I've left the tfsec version not updated so that we can test that the workflow happens at 4:40PM today.

* Add `shafile` to the gitignore because I don't want that coming into our repo when we curl it in the action
## Changelog or Releases

Add the changelog or release URL for the tool being updated. Some examples below (delete the ones that do not apply
for clarity).

- [AWS CLI](https://github.com/aws/aws-cli/blob/v2/CHANGELOG.rst)
- [atl🍑ntis](https://github.com/runatlantis/atlantis/releases)
- [chamber](https://github.com/segmentio/chamber/releases)
- [cypress](https://www.cypress.io/)
- [CircleCI](https://github.com/CircleCI-Public/circleci-cli/releases)
- [ecs-service-logs](https://github.com/trussworks/ecs-service-logs/releases)
- [find-guardduty-user](https://github.com/trussworks/find-guardduty-user/releases)
- [golang](https://golang.org/doc/devel/release.html)
- [Google Chrome](https://chromereleases.googleblog.com/)
- [shellcheck](https://github.com/koalaman/shellcheck/releases)
- [go-bindata](https://github.com/kevinburke/go-bindata/releases)
- [go-swagger](https://github.com/go-swagger/go-swagger/releases)
- [node 10.X](https://nodejs.org/en/about/releases/)
- [pre-commit](https://github.com/pre-commit/pre-commit/releases)
- [terraform-docs](https://github.com/segmentio/terraform-docs/releases)
- [terraform](https://github.com/hashicorp/terraform/releases)
- [tfsec](https://github.com/tfsec/tfsec/releases)
- [yarn](https://github.com/yarnpkg/yarn/releases)
