### PR TITLE
Fix GitHub action

### DIFF
--- a/.github/workflows/tfsec.yml
+++ b/.github/workflows/tfsec.yml
@@ -1,8 +1,8 @@
 name: Get latest tfsec version
 
-on: push
-  # schedule: 
-    # - cron: '40 21 * * *'
+on:
+  schedule: 
+    - cron: '0 14 * * *'
 
 jobs:
   update-tfsec:
@@ -54,7 +54,7 @@ jobs:
           token: ${{ secrets.ROBOT_MYMOVE_TOKEN }}
           commit-message: Update tfsec to new version
           author: ${GITHUB_ACTOR_NAME} <${GITHUB_ACTOR_EMAIL}>
-          branch: tfsec-update-test-${{ steps.get-versions.outputs.release_tag }}
+          branch: tfsec-update-${{ steps.get-versions.outputs.release_tag }}
           delete-branch: true
           title: Update tfsec Version to ${{ steps.get-versions.outputs.release_tag }}
           body: |

--- a/.github/workflows/tfsec.yml
+++ b/.github/workflows/tfsec.yml
@@ -1,8 +1,8 @@
 name: Get latest tfsec version
 
-on:
-  schedule: 
-    - cron: '40 21 * * *'
+on: push
+  # schedule: 
+    # - cron: '40 21 * * *'
 
 jobs:
   update-tfsec:
@@ -54,7 +54,7 @@ jobs:
           token: ${{ secrets.ROBOT_MYMOVE_TOKEN }}
           commit-message: Update tfsec to new version
           author: ${GITHUB_ACTOR_NAME} <${GITHUB_ACTOR_EMAIL}>
-          branch: tfsec-update-${{ steps.get-versions.outputs.release_tag }}
+          branch: tfsec-update-test-${{ steps.get-versions.outputs.release_tag }}
           delete-branch: true
           title: Update tfsec Version to ${{ steps.get-versions.outputs.release_tag }}
           body: |

--- a/.github/workflows/tfsec.yml
+++ b/.github/workflows/tfsec.yml
@@ -36,8 +36,8 @@ jobs:
           OLD_SHA256SUM: ${{ steps.checksum.outputs.current_sha256sum }}
           NEW_SHA256SUM: ${{ steps.checksum.outputs.release_sha256sum }}
         run: |
-          sed -i --expression="s/$OLD_VERSION/$NEW_VERSION/" $CURRENT_IMAGE_DIRECTORY/Dockerfile
-          sed -i --expression="s/$OLD_SHA256SUM/$NEW_SHA256SUM/" $CURRENT_IMAGE_DIRECTORY/Dockerfile
+          sed -i --expression="s/TFSEC_VERSION=$OLD_VERSION/TFSEC_VERSION=$NEW_VERSION/" $CURRENT_IMAGE_DIRECTORY/Dockerfile
+          sed -i --expression="s/TFSEC_SHA256SUM=$OLD_SHA256SUM/TFSEC_SHA256SUM=$NEW_SHA256SUM/" $CURRENT_IMAGE_DIRECTORY/Dockerfile
       - name: set up Git
         if: ${{ steps.get-versions.outputs.release_tag != steps.get-versions.outputs.current_tag }}
         env:

--- a/milmove-infra-tf112/Dockerfile
+++ b/milmove-infra-tf112/Dockerfile
@@ -29,8 +29,8 @@ RUN set -ex && cd ~ \
   && chmod 755 /usr/local/bin/terraform-docs
 
 #install tfsec
-ARG TFSEC_VERSION=1.1.2
-ARG TFSEC_SHA256SUM=e47bbbcfdc37f8967ea253618b33a128cd1faeab5e21105f0dc0bb69ab08d51e
+ARG TFSEC_VERSION=1.1.3
+ARG TFSEC_SHA256SUM=c58239548d7b6d943f760cf2ef8db1ab8247c0c7b957a46c01f61d81775fac59
 RUN set -ex && cd ~ \
   && curl -sSLO https://github.com/aquasecurity/tfsec/releases/download/v${TFSEC_VERSION}/tfsec-linux-amd64 \
   && [ $(sha256sum tfsec-linux-amd64 | cut -f1 -d' ') = ${TFSEC_SHA256SUM} ] \


### PR DESCRIPTION
# Description

Because the terraform and tfsec versions overlapped, the sed statement changed things we didn't want it to change: https://github.com/transcom/circleci-docker/pull/206

The result of this change is that our PRs will ensure to specifically target TFSEC, such as this one: https://github.com/transcom/circleci-docker/pull/207

## Changelog or Releases

Add the changelog or release URL for the tool being updated. Some examples below (delete the ones that do not apply
for clarity).

- [AWS CLI](https://github.com/aws/aws-cli/blob/v2/CHANGELOG.rst)
- [atl🍑ntis](https://github.com/runatlantis/atlantis/releases)
- [chamber](https://github.com/segmentio/chamber/releases)
- [cypress](https://www.cypress.io/)
- [CircleCI](https://github.com/CircleCI-Public/circleci-cli/releases)
- [ecs-service-logs](https://github.com/trussworks/ecs-service-logs/releases)
- [find-guardduty-user](https://github.com/trussworks/find-guardduty-user/releases)
- [golang](https://golang.org/doc/devel/release.html)
- [Google Chrome](https://chromereleases.googleblog.com/)
- [shellcheck](https://github.com/koalaman/shellcheck/releases)
- [go-bindata](https://github.com/kevinburke/go-bindata/releases)
- [go-swagger](https://github.com/go-swagger/go-swagger/releases)
- [node 10.X](https://nodejs.org/en/about/releases/)
- [pre-commit](https://github.com/pre-commit/pre-commit/releases)
- [terraform-docs](https://github.com/segmentio/terraform-docs/releases)
- [terraform](https://github.com/hashicorp/terraform/releases)
- [tfsec](https://github.com/tfsec/tfsec/releases)
- [yarn](https://github.com/yarnpkg/yarn/releases)
