### PR TITLE
[MB-11565] Upgrade to go-swagger 0.29.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .vscode/*
 *node_modules/
 shafile
+.idea

--- a/milmove-app/Dockerfile
+++ b/milmove-app/Dockerfile
@@ -30,8 +30,8 @@ RUN set -ex && cd ~ \
   && mv go-bindata-linux-amd64 /usr/local/bin/go-bindata
 
 # install swagger
-ARG SWAGGER_VERSION=0.28.0
-ARG SWAGGER_SHA256SUM=c9f1888afecb5cb6ddc041db5278f5102be7021f4475f43ec95bfd1289262044
+ARG SWAGGER_VERSION=0.29.0
+ARG SWAGGER_SHA256SUM=0666361b45e11862e3d6487693da9f498710e395660ed0fcbea835a9e8c7272d
 RUN set -ex && cd ~ \
   && curl -sSLO https://github.com/go-swagger/go-swagger/releases/download/v${SWAGGER_VERSION}/swagger_linux_amd64 \
   && [ $(sha256sum swagger_linux_amd64 | cut -f1 -d' ') = ${SWAGGER_SHA256SUM} ] \


### PR DESCRIPTION
# Description

This PR upgrades the version of go-swagger that appears inside of the Docker image from version 0.28.0 to version 0.29.0.

I also added the folder used by JetBrains IDEs to the `.gitignore` file.

## Changelog or Releases

- [go-swagger 0.29.0 release notes](https://github.com/go-swagger/go-swagger/releases/tag/v0.29.0)
