### PR TITLE
[MB-11847] Upgrade golang to 1.17.7

### DIFF
--- a/milmove-app/Dockerfile
+++ b/milmove-app/Dockerfile
@@ -11,8 +11,8 @@ USER root
 ENV GOFLAGS=-p=4
 
 # install go
-ARG GO_VERSION=1.17.5
-ARG GO_SHA256SUM=bd78114b0d441b029c8fe0341f4910370925a4d270a6a590668840675b0c653e
+ARG GO_VERSION=1.17.7
+ARG GO_SHA256SUM=02b111284bedbfa35a7e5b74a06082d18632eff824fd144312f6063943d49259
 RUN set -ex && cd ~ \
   && curl -sSLO https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz \
   && [ $(sha256sum go${GO_VERSION}.linux-amd64.tar.gz | cut -f1 -d' ') = ${GO_SHA256SUM} ] \


### PR DESCRIPTION
# Description

Update go from 1.17.5 to 1.17.7 in our docker images in anticipation of switching to Go 1.17.7 in milmove. This includes security fixes released in 1.17.7.

To verify that go 1.17.7 is in the container, do the following:

1. `docker pull milmove/circleci-docker:milmove-app-a944f0e14ba45fa65207b897b969e77840ed927b` (to pull down the image -- that hash matches the commit hash in this PR)
1. `docker images` (to see the current image list -- make note of the image ID for the image above)
1. `docker run -it <image ID> /bin/bash` (to run an interactive shell with that image)
1. While in the interactive shell, do a `go version` and verify that it says `1.17.7`
1. `exit` to get out of the interactive shell

## Changelog or Releases

Go 1.17.x version history:
https://golang.org/doc/devel/release.html#go1.17

## Reviewer Notes

I plan to test the milmove PR using this branch and only merge this PR once everything passes and seems OK.  I'll then update the new `master` hash in the milmove PR.
