### PR TITLE
[MB-11991] Update golang to 1.18

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,7 +14,7 @@ for clarity).
 - [CircleCI](https://github.com/CircleCI-Public/circleci-cli/releases)
 - [ecs-service-logs](https://github.com/trussworks/ecs-service-logs/releases)
 - [find-guardduty-user](https://github.com/trussworks/find-guardduty-user/releases)
-- [golang](https://golang.org/doc/devel/release.html)
+- [golang](https://go.dev/doc/devel/release)
 - [Google Chrome](https://chromereleases.googleblog.com/)
 - [shellcheck](https://github.com/koalaman/shellcheck/releases)
 - [go-bindata](https://github.com/kevinburke/go-bindata/releases)

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The base image is the absolute minimum of shared dependencies across all images
 
 In addition to the Base Image this contains:
 
-* [golang](https://golang.org/)
+* [golang](https://go.dev/)
 * [go-bindata](https://github.com/kevinburke/go-bindata)
 * [go-swagger](https://github.com/go-swagger/go-swagger)
 * [chamber](https://github.com/segmentio/chamber)
@@ -72,7 +72,7 @@ The code for [milmove/circleci-docker:milmove-orders](https://github.com/transco
 
 In addition to the Base Image this contained:
 
-* [golang](https://golang.org/)
+* [golang](https://go.dev/)
 * [go-swagger](https://github.com/go-swagger/go-swagger)
 * [chamber](https://github.com/segmentio/chamber)
 * Apt Packages

--- a/milmove-app/Dockerfile
+++ b/milmove-app/Dockerfile
@@ -11,10 +11,10 @@ USER root
 ENV GOFLAGS=-p=4
 
 # install go
-ARG GO_VERSION=1.17.7
-ARG GO_SHA256SUM=02b111284bedbfa35a7e5b74a06082d18632eff824fd144312f6063943d49259
+ARG GO_VERSION=1.18
+ARG GO_SHA256SUM=e85278e98f57cdb150fe8409e6e5df5343ecb13cebf03a5d5ff12bd55a80264f
 RUN set -ex && cd ~ \
-  && curl -sSLO https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz \
+  && curl -sSLO https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz \
   && [ $(sha256sum go${GO_VERSION}.linux-amd64.tar.gz | cut -f1 -d' ') = ${GO_SHA256SUM} ] \
   && tar -C /usr/local -xzf go${GO_VERSION}.linux-amd64.tar.gz \
   && ln -s /usr/local/go/bin/* /usr/local/bin \


### PR DESCRIPTION
# Description

Update go from 1.17.7 to 1.18 in our docker images in anticipation of switching to Go 1.18 in milmove.

To verify that go 1.18 is in the container, do the following:

1. `docker pull milmove/circleci-docker:milmove-app-64b1fa9ea8c2c7ed8d5773829c142c30190bc2fb` (to pull down the image -- that hash matches the commit hash in this PR)
1. `docker images` (to see the current image list -- make note of the image ID for the image above)
1. `docker run -it <image ID> /bin/bash` (to run an interactive shell with that image)
1. While in the interactive shell, do a `go version` and verify that it says `1.18`
1. `exit` to get out of the interactive shell

## Changelog or Releases

Go 1.18.x version history:
https://go.dev/doc/devel/release#go1.18

Go 1.18 detailed release notes:
https://go.dev/doc/go1.18

## Reviewer Notes

I plan to test the milmove PR using this branch and only merge this PR once everything passes and seems OK.  I'll then update the new `master` hash in the milmove PR.

I went ahead and changed some URLs that referenced `golang.org` to the [new `go.dev` domain](https://go.dev/blog/tidy-web) (old URLs work but redirect).

I also updated our pre-commit URLs to the `https` protocol instead of the deprecated `git` one (if you don't, you see an error with a `pre-commit autoupdate`).  After doing that, I updated all the pre-commit hook versions and fixed one file that was flagged with a trivial spacing issue.
