### PR TITLE
[MB-12078] add safe directory for all com modules

### DIFF
--- a/milmove-atlantis/Dockerfile
+++ b/milmove-atlantis/Dockerfile
@@ -18,6 +18,8 @@ RUN set -ex \
 # Install Python3 for Lambdas
 RUN apk add --no-cache python3
 
+RUN git config --global --add safe.directory /home/atlantis/.atlantis/repos/transcom/transcom-infrasec-com/
+
 LABEL name="atlantis"
 
 ENV DEFAULT_TERRAFORM_VERSION=1.1.2


### PR DESCRIPTION
We may need to revert if this doesn't work. Trying to fix an issue with atlantis that resulted from this vulnerability being discovered: https://github.blog/2022-04-12-git-security-vulnerability-announced/