### PR TITLE
Attempting to set GIT_CEILING_DIRECTORIES

### DIFF
--- a/milmove-atlantis/Dockerfile
+++ b/milmove-atlantis/Dockerfile
@@ -18,10 +18,9 @@ RUN set -ex \
 # Install Python3 for Lambdas
 RUN apk add --no-cache python3
 
-RUN git config --global --add safe.directory "*"
-
 LABEL name="atlantis"
 
 ENV DEFAULT_TERRAFORM_VERSION=1.1.2
+ENV GIT_CEILING_DIRECTORIES="/home/atlantis/.atlantis/repos/transcom/transcom-infrasec-com"
 
 EXPOSE 4141


### PR DESCRIPTION
# Description

According to this troubleshooting post around Ansible, the environment
variable works similarly to the suggestion of using `git config` and is
recommended when using Docker. So let's try that and see if this helps.

[=> What to do when Git reports Fatal: Unsafe Repository](https://communities.sas.com/t5/SAS-Communities-Library/What-to-do-when-Git-reports-Fatal-Unsafe-Repository/ta-p/808910)

This could possibly unstuck transcom/transcom-infrasec-com#1944