### PR TITLE
[MB-12078] another attempt to fix atlantis

### DIFF
--- a/milmove-atlantis/Dockerfile
+++ b/milmove-atlantis/Dockerfile
@@ -13,7 +13,8 @@ FROM runatlantis/atlantis:v0.18.1
 RUN set -ex \
     && apk update \
     && apk upgrade --no-cache \
-    && rm -rf /var/cache/apk/*
+    && rm -rf /var/cache/apk/* \
+    && git config --system --add safe.directory /home/atlantis/.atlantis/repos/transcom/transcom-infrasec-com
 
 # Install Python3 for Lambdas
 RUN apk add --no-cache python3
@@ -21,6 +22,5 @@ RUN apk add --no-cache python3
 LABEL name="atlantis"
 
 ENV DEFAULT_TERRAFORM_VERSION=1.1.2
-ENV GIT_CEILING_DIRECTORIES="/home/atlantis/.atlantis/repos/transcom/transcom-infrasec-com"
 
 EXPOSE 4141


### PR DESCRIPTION
dug into [this post](https://communities.sas.com/t5/SAS-Communities-Library/What-to-do-when-Git-reports-Fatal-Unsafe-Repository/ta-p/808910) and ended up finding an example in https://github.com/sassoftware/viya4-deployment where they use the --system flag instead of --global