### PR TITLE
MB-13121 Update go version to 1.18.4 for milmove-app/Dockerfile

### DIFF
--- a/milmove-app/Dockerfile
+++ b/milmove-app/Dockerfile
@@ -11,8 +11,8 @@ USER root
 ENV GOFLAGS=-p=4
 
 # install go
-ARG GO_VERSION=1.18.1
-ARG GO_SHA256SUM=b3b815f47ababac13810fc6021eb73d65478e0b2db4b09d348eefad9581a2334
+ARG GO_VERSION=1.18.4
+ARG GO_SHA256SUM=c9b099b68d93f5c5c8a8844a89f8db07eaa58270e3a1e01804f17f4cf8df02f5
 RUN set -ex && cd ~ \
   && curl -sSLO https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz \
   && [ $(sha256sum go${GO_VERSION}.linux-amd64.tar.gz | cut -f1 -d' ') = ${GO_SHA256SUM} ] \


### PR DESCRIPTION
# Description

Update go from 1.18.1 to 1.18.4 Includes release with security fixes.

## Changelog or Releases

- [golang](https://go.dev/doc/devel/release)
    - go1.18.2 (released 2022-05-10) includes security fixes to the syscall package, as well as bug fixes to the compiler, runtime, the go command, and the crypto/x509, go/types, net/http/httptest, reflect, and sync/atomic packages. See the [Go 1.18.2 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.18.2+label%3ACherryPickApproved) on our issue tracker for details.
    - go1.18.3 (released 2022-06-01) includes security fixes to the crypto/rand, crypto/tls, os/exec, and path/filepath packages, as well as bug fixes to the compiler, and the crypto/tls and text/template/parse packages. See the [Go 1.18.3 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.18.3+label%3ACherryPickApproved) on our issue tracker for details.
    - go1.18.4 (released 2022-07-12) includes security fixes to the compress/gzip, encoding/gob, encoding/xml, go/parser, io/fs, net/http, and path/filepath packages, as well as bug fixes to the compiler, the go command, the linker, the runtime, and the runtime/metrics package. See the [Go 1.18.4 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.18.4+label%3ACherryPickApproved) on our issue tracker for details.

## Testing New Docker Image

1. Pull down the new image:

    ```shell
    docker pull milmove/circleci-docker:milmove-app-c37732bd3d055d26c0a921f627a292847e4e3f00
    ```

1. Check the version of `go` in the image

    ```shell
    docker run --rm $(docker image list -f "reference=milmove/circleci-docker:milmove-app-c37732bd3d055d26c0a921f627a292847e4e3f00" --format "{{.ID}}") go version
    ```

    1. Should output something like: `go version go1.18.4 linux/amd64`