### PR TITLE
update tfsec to version 1.26.3

### DIFF
--- a/milmove-infra-tf112/Dockerfile
+++ b/milmove-infra-tf112/Dockerfile
@@ -29,8 +29,8 @@ RUN set -ex && cd ~ \
   && chmod 755 /usr/local/bin/terraform-docs
 
 #install tfsec
-ARG TFSEC_VERSION=1.25.1
-ARG TFSEC_SHA256SUM=f690ae540685d81dbc1c8b28766c7175c3469398b68a8b50d5a03be6190d951b
+ARG TFSEC_VERSION=1.26.3
+ARG TFSEC_SHA256SUM=77c89db35c792c64a011927577ccafee0b6b65a64def593c3b196ba34f778663
 RUN set -ex && cd ~ \
   && curl -sSLO https://github.com/aquasecurity/tfsec/releases/download/v${TFSEC_VERSION}/tfsec-linux-amd64 \
   && [ $(sha256sum tfsec-linux-amd64 | cut -f1 -d' ') = ${TFSEC_SHA256SUM} ] \


### PR DESCRIPTION
the automatic updater won't run on circleci and I haven't been able to figure it out :/ 