### PR TITLE
NT: Missed 2 spots for the master=> main rename

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,8 +53,8 @@ jobs:
               docker push milmove/circleci-docker:milmove-atlantis-$tag
             done
 
-            # push default tags on master
-            if [[ $CIRCLE_BRANCH = master ]]; then
+            # push default tags on main
+            if [[ $CIRCLE_BRANCH = main ]]; then
               docker push milmove/circleci-docker
               docker push milmove/circleci-docker:milmove-app
               docker push milmove/circleci-docker:milmove-cypress

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Transcom CircleCI Docker Images
 
-[![CircleCI](https://circleci.com/gh/transcom/circleci-docker/tree/master.svg?style=svg)](https://circleci.com/gh/transcom/circleci-docker/tree/master)
+[![CircleCI](https://dl.circleci.com/status-badge/img/gh/transcom/circleci-docker/tree/main.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/transcom/circleci-docker/tree/main)
 
 This repository manages the custom-built docker images for use with CircleCI and development. Each image contains the minimum necessary tools to run testing and development.
 
@@ -27,7 +27,7 @@ For the latest stable images:
 * `milmove/circleci-docker:milmove-infra-tf104`
 * `milmove/circleci-docker:milmove-atlantis`
 
-For static tags, use tags including the git hash. You can find the hashes in this repo, from the [CircleCI builds page](https://circleci.com/gh/milmove/circleci-docker/tree/master), or from the [Docker Hub tags](https://hub.docker.com/r/milmove/circleci-docker/tags/) page.
+For static tags, use tags including the git hash. You can find the hashes in this repo, from the [CircleCI builds page](https://circleci.com/gh/milmove/circleci-docker/tree/main), or from the [Docker Hub tags](https://hub.docker.com/r/milmove/circleci-docker/tags/) page.
 
 ### Base Image
 


### PR DESCRIPTION
# Description
- updates the build file
- updates documentation that was still referencing master, including the status badge.

## Changelog or Releases

Add the changelog or release URL for the tool being updated. Some examples below (delete the ones that do not apply
for clarity).

- [AWS CLI](https://github.com/aws/aws-cli/blob/v2/CHANGELOG.rst)
- [atl🍑ntis](https://github.com/runatlantis/atlantis/releases)
- [chamber](https://github.com/segmentio/chamber/releases)
- [cypress](https://www.cypress.io/)
- [CircleCI](https://github.com/CircleCI-Public/circleci-cli/releases)
- [ecs-service-logs](https://github.com/trussworks/ecs-service-logs/releases)
- [find-guardduty-user](https://github.com/trussworks/find-guardduty-user/releases)
- [golang](https://go.dev/doc/devel/release)
- [Google Chrome](https://chromereleases.googleblog.com/)
- [shellcheck](https://github.com/koalaman/shellcheck/releases)
- [go-bindata](https://github.com/kevinburke/go-bindata/releases)
- [go-swagger](https://github.com/go-swagger/go-swagger/releases)
- [node 10.X](https://nodejs.org/en/about/releases/)
- [pre-commit](https://github.com/pre-commit/pre-commit/releases)
- [terraform-docs](https://github.com/segmentio/terraform-docs/releases)
- [terraform](https://github.com/hashicorp/terraform/releases)
- [tfsec](https://github.com/tfsec/tfsec/releases)
- [yarn](https://github.com/yarnpkg/yarn/releases)
