### PR TITLE
[MB-13881] Upgrade go-swagger to version 0.30.2

### DIFF
--- a/milmove-app/Dockerfile
+++ b/milmove-app/Dockerfile
@@ -30,8 +30,8 @@ RUN set -ex && cd ~ \
   && mv go-bindata-linux-amd64 /usr/local/bin/go-bindata
 
 # install swagger
-ARG SWAGGER_VERSION=0.29.0
-ARG SWAGGER_SHA256SUM=0666361b45e11862e3d6487693da9f498710e395660ed0fcbea835a9e8c7272d
+ARG SWAGGER_VERSION=0.30.2
+ARG SWAGGER_SHA256SUM=767b79fdb84aaf0da67a24b358d7d3ff298788e27095255f1cae08057bde7508
 RUN set -ex && cd ~ \
   && curl -sSLO https://github.com/go-swagger/go-swagger/releases/download/v${SWAGGER_VERSION}/swagger_linux_amd64 \
   && [ $(sha256sum swagger_linux_amd64 | cut -f1 -d' ') = ${SWAGGER_SHA256SUM} ] \


### PR DESCRIPTION
# Description

This PR upgrades the version of go-swagger that appears inside of the Docker image from version 0.29.0 to version 0.30.2.

## Changelog or Releases

- [go-swagger 0.30.2 release notes](https://github.com/go-swagger/go-swagger/releases/tag/v0.30.2)
- [go-swagger 0.30.0 release notes](https://github.com/go-swagger/go-swagger/releases/tag/v0.30.0)
