### PR TITLE
MB-13870: Update go version to 1.19.1

### DIFF
--- a/milmove-app/Dockerfile
+++ b/milmove-app/Dockerfile
@@ -11,8 +11,8 @@ USER root
 ENV GOFLAGS=-p=4
 
 # install go
-ARG GO_VERSION=1.18.4
-ARG GO_SHA256SUM=c9b099b68d93f5c5c8a8844a89f8db07eaa58270e3a1e01804f17f4cf8df02f5
+ARG GO_VERSION=1.19.1
+ARG GO_SHA256SUM=acc512fbab4f716a8f97a8b3fbaa9ddd39606a28be6c2515ef7c6c6311acffde
 RUN set -ex && cd ~ \
   && curl -sSLO https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz \
   && [ $(sha256sum go${GO_VERSION}.linux-amd64.tar.gz | cut -f1 -d' ') = ${GO_SHA256SUM} ] \


### PR DESCRIPTION
# Description

Update go from 1.18.4 to 1.19.1. 

Following instructions from [https://github.com/transcom/mymove/wiki/upgrade-go-version](https://github.com/transcom/mymove/wiki/upgrade-go-version)

## Changelog or Releases

- [golang](https://go.dev/doc/devel/release)
  - go1.18.5 (released 2022-08-01) includes security fixes to the encoding/gob and math/big packages, as well as bug fixes to the compiler, the go command, the runtime, and the testing package. See the [Go 1.18.5 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.18.5+label%3ACherryPickApproved) on our issue tracker for details.
  - go1.18.6 (released 2022-09-06) includes security fixes to the net/http package, as well as bug fixes to the compiler, the go command, the pprof command, the runtime, and the crypto/tls, encoding/xml, and net packages. See the [Go 1.18.6 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.18.6+label%3ACherryPickApproved) on our issue tracker for details. 
  - Go 1.19 is a major release of Go. Read the [Go 1.19 Release Notes](https://go.dev/doc/go1.19) for more information.
    - Minor revisions
      - go1.19.1 (released 2022-09-06) includes security fixes to the net/http and net/url packages, as well as bug fixes to the compiler, the go command, the pprof command, the linker, the runtime, and the crypto/tls and crypto/x509 packages. See the [Go 1.19.1 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.19.1+label%3ACherryPickApproved) on our issue tracker for details.
