### PR TITLE
[MB-14038] Remove go-swagger from milmove app docker image

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,7 +18,6 @@ for clarity).
 - [Google Chrome](https://chromereleases.googleblog.com/)
 - [shellcheck](https://github.com/koalaman/shellcheck/releases)
 - [go-bindata](https://github.com/kevinburke/go-bindata/releases)
-- [go-swagger](https://github.com/go-swagger/go-swagger/releases)
 - [node 10.X](https://nodejs.org/en/about/releases/)
 - [pre-commit](https://github.com/pre-commit/pre-commit/releases)
 - [terraform-docs](https://github.com/segmentio/terraform-docs/releases)

--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ In addition to the Base Image this contains:
 
 * [golang](https://go.dev/)
 * [go-bindata](https://github.com/kevinburke/go-bindata)
-* [go-swagger](https://github.com/go-swagger/go-swagger)
 * [chamber](https://github.com/segmentio/chamber)
 * Apt Packages
   * [NodeJS](https://nodejs.org/en/) at version 16.x (required for supporting USWDS)
@@ -72,7 +71,6 @@ The code for [milmove/circleci-docker:milmove-orders](https://github.com/transco
 In addition to the Base Image this contained:
 
 * [golang](https://go.dev/)
-* [go-swagger](https://github.com/go-swagger/go-swagger)
 * [chamber](https://github.com/segmentio/chamber)
 * Apt Packages
   * postgresql-client

--- a/milmove-app/Dockerfile
+++ b/milmove-app/Dockerfile
@@ -29,16 +29,6 @@ RUN set -ex && cd ~ \
   && chmod 755 go-bindata-linux-amd64 \
   && mv go-bindata-linux-amd64 /usr/local/bin/go-bindata
 
-# install swagger
-ARG SWAGGER_VERSION=0.30.2
-ARG SWAGGER_SHA256SUM=767b79fdb84aaf0da67a24b358d7d3ff298788e27095255f1cae08057bde7508
-RUN set -ex && cd ~ \
-  && curl -sSLO https://github.com/go-swagger/go-swagger/releases/download/v${SWAGGER_VERSION}/swagger_linux_amd64 \
-  && [ $(sha256sum swagger_linux_amd64 | cut -f1 -d' ') = ${SWAGGER_SHA256SUM} ] \
-  && chmod 755 swagger_linux_amd64 \
-  && ls -alh swagger_linux_amd64 \
-  && mv swagger_linux_amd64 /usr/local/bin/swagger
-
 ARG ECS_SERVICE_LOGS_VERSION=0.3.0
 ARG ECS_SERVICE_LOGS_SHA256SUM=2803177477bb917a19fc89f36f4972af740f80d35380cbe2c97345bb6d109f8e
 RUN set -ex && cd ~ \

--- a/test
+++ b/test
@@ -25,7 +25,6 @@ function test_milmove_app() {
 
   docker run -it "milmove/circleci-docker:${tag}" go version
   docker run -it "milmove/circleci-docker:${tag}" go-bindata --version
-  docker run -it "milmove/circleci-docker:${tag}" swagger version
   docker run -it "milmove/circleci-docker:${tag}" node --version
   docker run -it "milmove/circleci-docker:${tag}" yarn --version
   docker run -it "milmove/circleci-docker:${tag}" which entr


### PR DESCRIPTION
# Description

This PR removes [go-swagger](https://github.com/go-swagger/go-swagger) from the docker container.  This is a companion to [this ticket](https://github.com/transcom/mymove/pull/9352) on the MilMove side which is attempting to use a `go-swagger` that is managed via go as opposed to pre-installed in the docker container.  We've been having some issues with people [running differently-sourced/compiled versions](https://ustcdp3.slack.com/archives/CP6PTUPQF/p1663192043851619).

Don't merge this PR until we are sure that everything seems to be working on the MilMove side.  Once it's merged, then I'll update the hashes on the MilMove PR before merging it.