### PR TITLE
Add "apt-get update" to avoid fetch error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,6 +67,7 @@ RUN set -ex && cd ~ \
 ARG CACHE_APT
 RUN set -ex && cd ~ \
   && : Install apt packages \
+  && apt-get -qq update \
   && apt-get -qq -y install --no-install-recommends apt-transport-https groff less lsb-release \
   && : Cleanup \
   && apt-get clean \


### PR DESCRIPTION
# Description

The last couple of pull requests have failed to build due to [this error](https://app.circleci.com/pipelines/github/transcom/circleci-docker/921/workflows/87f8483e-7ee4-4708-bb85-f417eb3e61d6/jobs/984):

```
+ : Install apt packages
+ apt-get -qq -y install --no-install-recommends apt-transport-https groff less lsb-release
E: Failed to fetch http://deb.debian.org/debian/pool/main/d/distro-info-data/distro-info-data_0.41+deb10u4_all.deb  404  Not Found [IP: 146.75.34.132 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
The command '/bin/sh -c set -ex && cd ~   && : Install apt packages   && apt-get -qq -y install --no-install-recommends apt-transport-https groff less lsb-release   && : Cleanup   && apt-get clean   && rm -vrf /var/lib/apt/lists/*' returned a non-zero code: 100
make: *** [Makefile:7: build] Error 100
```

I *think* all we need to do is make sure we do an `apt-get update` prior to doing the install (that's also what the error message suggests).  Note that we were already doing an update before install in other Dockerfiles, but just not this top-level one for some reason.

To test, run a `make build` locally and see if it passes.  Also, this PR itself should pass checks unlike the other recent ones.