### PR TITLE
MB-14310: Updates Go version to 1.19.2

### DIFF
--- a/milmove-app/Dockerfile
+++ b/milmove-app/Dockerfile
@@ -11,8 +11,8 @@ USER root
 ENV GOFLAGS=-p=4
 
 # install go
-ARG GO_VERSION=1.19.1
-ARG GO_SHA256SUM=acc512fbab4f716a8f97a8b3fbaa9ddd39606a28be6c2515ef7c6c6311acffde
+ARG GO_VERSION=1.19.2
+ARG GO_SHA256SUM=5e8c5a74fe6470dd7e055a461acda8bb4050ead8c2df70f227e3ff7d8eb7eeb6
 RUN set -ex && cd ~ \
   && curl -sSLO https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz \
   && [ $(sha256sum go${GO_VERSION}.linux-amd64.tar.gz | cut -f1 -d' ') = ${GO_SHA256SUM} ] \


### PR DESCRIPTION
# Description

Updates go from 1.19.1 to 1.19.2. Includes release with security fixes.

Following instructions from https://transcom.github.io/mymove-docs/docs/backend/guides/how-to/upgrade-go-version/

## Changelog or Releases

- [golang](https://go.dev/doc/devel/release)
  - go1.19.2 (released 2022-10-04) includes security fixes to the `archive/tar`, `net/http/httputil`, and `regexp` packages, as well as bug fixes to the compiler, the linker, the runtime, and the go/types package.