### PR TITLE
[MB-14371] Update golang to 1.19.3

### DIFF
--- a/milmove-app/Dockerfile
+++ b/milmove-app/Dockerfile
@@ -11,8 +11,8 @@ USER root
 ENV GOFLAGS=-p=4
 
 # install go
-ARG GO_VERSION=1.19.2
-ARG GO_SHA256SUM=5e8c5a74fe6470dd7e055a461acda8bb4050ead8c2df70f227e3ff7d8eb7eeb6
+ARG GO_VERSION=1.19.3
+ARG GO_SHA256SUM=74b9640724fd4e6bb0ed2a1bc44ae813a03f1e72a4c76253e2d5c015494430ba
 RUN set -ex && cd ~ \
   && curl -sSLO https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz \
   && [ $(sha256sum go${GO_VERSION}.linux-amd64.tar.gz | cut -f1 -d' ') = ${GO_SHA256SUM} ] \


### PR DESCRIPTION
# Description

Update go from 1.19.2 to 1.19.3 in our docker images in anticipation of switching to Go 1.19.3 in milmove.

To verify that go 1.19.3 is in the container, do the following:

1. `docker pull milmove/circleci-docker:milmove-app-50574f57827a7977149b68f02d497c47e062d472` (to pull down the image -- that hash matches the commit hash in this PR)
1. `docker images` (to see the current image list -- make note of the image ID for the image above)
1. `docker run -it <image ID> /bin/bash` (to run an interactive shell with that image)
1. While in the interactive shell, do a `go version` and verify that it says `1.19.3`
1. `exit` to get out of the interactive shell

I generally followed [these upgrade instructions](https://transcom.github.io/mymove-docs/docs/backend/guides/how-to/upgrade-go-version).

## Changelog or Releases

Go 1.19.x version history:
https://go.dev/doc/devel/release#go1.19

## Reviewer Notes

I plan to test the milmove PR using this branch and only merge this PR once everything passes and seems OK.  I'll then update the new `master` hash in the milmove PR.
