### PR TITLE
Rollback tfsec to 1.28.0

### DIFF
--- a/milmove-infra-tf132/Dockerfile
+++ b/milmove-infra-tf132/Dockerfile
@@ -30,7 +30,7 @@ RUN set -ex && cd ~ \
 
 #install tfsec
 ARG TFSEC_VERSION=1.28.0
-ARG TFSEC_SHA256SUM=17c1bd99ebe13be77ac775651bc61f44b2b4409b4578485f1168eab8c3e97507
+ARG TFSEC_SHA256SUM=754c6f591e3110ca67c6b591921df86f7fcb28e12995dbfae7453e472de54f3b
 RUN set -ex && cd ~ \
   && curl -sSLO https://github.com/aquasecurity/tfsec/releases/download/v${TFSEC_VERSION}/tfsec-linux-amd64 \
   && [ $(sha256sum tfsec-linux-amd64 | cut -f1 -d' ') = ${TFSEC_SHA256SUM} ] \

--- a/milmove-infra-tf132/Dockerfile
+++ b/milmove-infra-tf132/Dockerfile
@@ -29,7 +29,7 @@ RUN set -ex && cd ~ \
   && chmod 755 /usr/local/bin/terraform-docs
 
 #install tfsec
-ARG TFSEC_VERSION=1.28.1
+ARG TFSEC_VERSION=1.28.0
 ARG TFSEC_SHA256SUM=17c1bd99ebe13be77ac775651bc61f44b2b4409b4578485f1168eab8c3e97507
 RUN set -ex && cd ~ \
   && curl -sSLO https://github.com/aquasecurity/tfsec/releases/download/v${TFSEC_VERSION}/tfsec-linux-amd64 \


### PR DESCRIPTION
# Description

Rolling back tfsec to [1.28.0](https://github.com/aquasecurity/tfsec/releases/tag/v1.28.0) due to [bug](https://github.com/aquasecurity/tfsec/issues/1936)

## Changelog or Releases

Add the changelog or release URL for the tool being updated. Some examples below (delete the ones that do not apply
for clarity).

- [tfsec](https://github.com/tfsec/tfsec/releases)
