### PR TITLE
[ spike ] Add a workflow for building containers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,8 @@
 version: 2
 jobs:
-  build:
+  test-branch-name:
     machine: true
     steps:
-      - checkout
       - run:
           name: Check for reserved branch names
           command: |
@@ -11,6 +10,11 @@ jobs:
               echo "Don't use a branch named 'latest', 'milmove-app', 'milmove-cypress', 'milmove-infra-tf112', 'milmove-infra-tf132'; these are meaningful tags."
               exit 1
             fi
+
+  build:
+    machine: true
+    steps:
+      - checkout
       - run:
           name: Login to Docker Hub
           command: docker login -u $DOCKER_USER -p $DOCKER_PASS
@@ -67,7 +71,10 @@ workflows:
   version: 2
   build-containers:
     jobs:
+      - test-branch-name
       - build:
+          requires:
+            - test-branch-name
           filters:
             branches:
               # NOTE: These branches are ignored because we use them when

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2
 jobs:
-  build:
+  build-containers:
     machine: true
     steps:
       - checkout
@@ -62,3 +62,19 @@ jobs:
               docker push milmove/circleci-docker:milmove-infra-tf132
               docker push milmove/circleci-docker:milmove-atlantis
             fi
+
+workflows:
+  version: 2
+  build-containers:
+    jobs:
+      - build-containers:
+          filters:
+            branches:
+              # NOTE: These branches are ignored because we use them when
+              # building containers for the application and infrastructure.
+              ignore:
+                - latest
+                - milmove-app
+                - milmove-cypress
+                - milmove-infra-tf132
+                - milmove-infra-tf112

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2
 jobs:
-  build-containers:
+  build:
     machine: true
     steps:
       - checkout
@@ -67,7 +67,7 @@ workflows:
   version: 2
   build-containers:
     jobs:
-      - build-containers:
+      - build:
           filters:
             branches:
               # NOTE: These branches are ignored because we use them when

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,13 +3,20 @@ jobs:
   test-branch-name:
     machine: true
     steps:
+      - checkout
       - run:
           name: Check for reserved branch names
           command: |
-            if [[ $CIRCLE_BRANCH = latest || $CIRCLE_BRANCH = milmove-app || $CIRCLE_BRANCH = milmove-cypress || $CIRCLE_BRANCH = milmove-infra-tf132 || $CIRCLE_BRANCH = milmove-infra-tf112 ]]; then
-              echo "Don't use a branch named 'latest', 'milmove-app', 'milmove-cypress', 'milmove-infra-tf112', 'milmove-infra-tf132'; these are meaningful tags."
-              exit 1
-            fi
+            important_branches=( $(ls -d * | grep milmove) latest )
+            for branch in "${important_branches[@]}"
+            do
+              if test "${CIRCLE_BRANCH}" == ${branch}
+              then
+                echo "Don't use meaningful tags for a branch name!"
+                echo "Don't use a branch named ${branch}."
+                exit 1
+              fi
+            done
 
   build:
     machine: true
@@ -82,6 +89,7 @@ workflows:
               ignore:
                 - latest
                 - milmove-app
+                - milmove-atlantis
                 - milmove-cypress
                 - milmove-infra-tf132
                 - milmove-infra-tf112

--- a/README.md
+++ b/README.md
@@ -14,6 +14,27 @@ the public domain. In places where it is eligible for copyright, such as some fo
 this work is licensed under [the MIT License](https://opensource.org/licenses/MIT), the full text of which is included
 in the [LICENSE.txt](./LICENSE.txt) file in this repository.
 
+## CI/CD
+
+This repository uses Workflows to build the containers. The main job is a
+`build` job for historical reasons. The workflows filter on certain branches
+that match the releases of the Docker images. Branches that get created in this
+repository with any of the following names will not build.
+
+* `latest`
+* `milmove-app`
+* `milmove-cypress`
+* `milmove-atlantis`
+* `milmove-cypress`
+* `milmove-infra-tf112`
+* `milmove-infra-tf132`
+
+The main workflow is named `build-containers` and runs `test-branch-name` to
+check if the name of the branch matches any of the name of the containers that
+get built. Take care naming your branches as if the `test-branch-name` job
+fails, it will not allow the `build` command to run which will not allow PRs to
+get merged in.
+
 ## Images
 
 Each image is specifically tailored.
@@ -24,6 +45,7 @@ For the latest stable images:
 * `milmove/circleci-docker:base`
 * `milmove/circleci-docker:milmove-app`
 * `milmove/circleci-docker:milmove-cypress`
+* `milmove/circleci-docker:milmove-infra-tf112`
 * `milmove/circleci-docker:milmove-infra-tf132`
 * `milmove/circleci-docker:milmove-atlantis`
 


### PR DESCRIPTION
# Description

This came out of the work involved in #339. This patch is only here to update
and re-enforce the work that already exists in the CircleCI build script today.
Essentially, the workflow is called `build-containers` and calls the job `build`
and filters on branches named after the checks in the current Build step named
_Check for reserved branch names_. While this check is useful on it's own to be
informative for developers, the check in the workflow does at least two things
well.

- Informs developers that their PR cannot and will not be merged in due to the
  `build` job never running.
- Informs developers / operators of features for CI/CD that help perform
  filtering and pattern matching for CircleCI.

