### PR TITLE
[ spike ] Adding the pre-commit CirlceCI task

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,3 +16,10 @@ repos:
     hooks:
     -   id: dockerfilelint
         stages: [commit]
+
+- repo: https://github.com/zahorniak/pre-commit-circleci.git
+  rev: v0.6
+  hooks:
+    - id: circleci_validate
+      args:
+        - .circleci/config.yml


### PR DESCRIPTION
# Description

Adding the `pre-commit` CircleCI job. This is part of my pre-vacation spikes to
help with developer experience on the project.

