### PR TITLE
[ spike, MB-14548, MB-13732 ] Refactor the release script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,43 +36,7 @@ jobs:
 
       - run:
           name: Release container
-          command: |
-            shopt -s extglob
-            for tag in $CIRCLE_SHA1 ${CIRCLE_BRANCH//+([^A-Za-z0-9-.])/-}; do
-              # latest
-              docker tag  milmove/circleci-docker milmove/circleci-docker:$tag
-              docker push milmove/circleci-docker:$tag
-
-              # milmove-app
-              docker tag  milmove/circleci-docker:milmove-app milmove/circleci-docker:milmove-app-$tag
-              docker push milmove/circleci-docker:milmove-app-$tag
-
-              # milmove-cypress
-              docker tag  milmove/circleci-docker:milmove-cypress milmove/circleci-docker:milmove-cypress-$tag
-              docker push milmove/circleci-docker:milmove-cypress-$tag
-
-              # milmove-infra-tf112
-              docker tag  milmove/circleci-docker:milmove-infra-tf112 milmove/circleci-docker:milmove-infra-tf112-$tag
-              docker push milmove/circleci-docker:milmove-infra-tf112-$tag
-
-              # milmove-infra-tf132
-              docker tag  milmove/circleci-docker:milmove-infra-tf132 milmove/circleci-docker:milmove-infra-tf132-$tag
-              docker push milmove/circleci-docker:milmove-infra-tf132-$tag
-
-              # milmove-atlantis
-              docker tag  milmove/circleci-docker:milmove-atlantis milmove/circleci-docker:milmove-atlantis-$tag
-              docker push milmove/circleci-docker:milmove-atlantis-$tag
-            done
-
-            # push default tags on main
-            if [[ $CIRCLE_BRANCH = main ]]; then
-              docker push milmove/circleci-docker
-              docker push milmove/circleci-docker:milmove-app
-              docker push milmove/circleci-docker:milmove-cypress
-              docker push milmove/circleci-docker:milmove-infra-tf112
-              docker push milmove/circleci-docker:milmove-infra-tf132
-              docker push milmove/circleci-docker:milmove-atlantis
-            fi
+          command: make release
 
 workflows:
   version: 2

--- a/release
+++ b/release
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -x -eu -o pipefail
+
+set +u
+if [ -z "$CI" ]; then # protective magick
+  echo "This script must be run inside a CI environment."
+  exit 0
+fi
+set -u
+
+#shellcheck disable=SC2010,SC2207
+reserved_tags=( $(ls -d -- * | grep milmove ) latest )
+
+for tag in "${reserved_tags[@]}"
+do
+  shopt -s extglob
+  for sha in $CIRCLE_SHA1 ${CIRCLE_BRANCH//+([^A-Za-z0-9-.])/-}
+  do
+    # README: Since `latest` is reserved for the main Dockerfile, we need to
+    # make a special case for it since the other tags names come from the
+    # directories in the repository.
+    if test "${tag}" == "latest"
+    then
+      docker tag  milmove/circleci-docker "milmove/circleci-docker:${sha}"
+      docker push "milmove/circleci-docker:${sha}"
+    else
+      docker tag "milmove/circleci-docker:${tag}" "milmove/circleci-docker:${tag}-${sha}"
+      docker push "milmove/circleci-docker:${tag}-${sha}"
+    fi
+  done
+done
+
+
+
+set +u
+# push latest tags on main
+if [[ $CIRCLE_BRANCH = main ]]; then
+  for tag in "${reserved_tags[@]}"
+  do
+    if test "${tag}" == "latest"
+    then
+      docker push milmove/circleci-docker
+    else
+      docker push "milmove/circleci-docker:${tag}"
+    fi
+  done
+fi
+set -u


### PR DESCRIPTION
# Description

This refactor is going to come in handy much later. But for now the refactor is focusing on not repeating ourselves similar to the `test-branch-name` where it iterates on the folders in the repository while reserving the `latest` word for the base or root `Dockerfile`.

Inspired by the work suggested in #339 between @ahobson and @rogeruiz.

This work will be further built on in future patches. I'll update this section once those PRs are created. This whole idea will hopefully replace the need for #339 to exist at all.