### PR TITLE
[MB-15041, MB-15155] Updating deprecated docker repository reference and base image version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # CircleCI docker image to run within
-FROM circleci/python:3.10.1-buster-node
+FROM cimg/python:3.10.7-node
 # Base image uses "circleci", to avoid using `sudo` run as root user
 USER root
 


### PR DESCRIPTION
# Description

### [JIRA ticket](https://dp3.atlassian.net/browse/MB-15041)

We have been using `circleci/python:3.10.1-buster-node` as the base image for our various circleci-docker images (milmove-cypress, milmove-app, etc.).  However, I recently noticed the following:

- We used to get [dependabot updates](https://github.com/transcom/circleci-docker/pulls?q=buster-node) for this base image, but we haven't gotten one in over a year.
- It appears that the docker repository changed from [circleci/python](https://hub.docker.com/r/circleci/python) to [cimg/python](https://hub.docker.com/r/cimg/python) a while back, so dependabot hasn't been aware of any updates from the new repository ([more detail here](https://circleci.com/docs/next-gen-migration-guide/)).
- I also don't see the `buster` variant in the new repo (I believe that's referring to Debian 10). The corresponding 3.10.1 version from the new repo (`cimg/python:3.10.1-node`) appears to be based on Ubuntu 20. The python (3.10.1) and node (16.13.1) versions match though.

In this PR, I've moved us to the new repository and updated us to `cimg/python:3.10.7-node`.  That's the last version of their `node` image variant that has `node 16.x` (specifically, it has v16.17.0).  It's based on `Ubuntu 20.04.4 LTS`.  There are later images, but I had to stay back on this one because later ones have node 18.x and that [doesn't seem to play well](https://app.circleci.com/pipelines/github/transcom/mymove/49254/workflows/fbe66122-2cad-4b2e-841d-43f78f7e6bcc) with cypress 8.5.0 (the version we're stuck on for now).  Since we're hoping to switch from cypress to playwright, we can hopefully see about moving forward to a later version after that switch.  But at least updating to this base image gets us a little further along and off of a deprecated image.

I know Ubuntu is derived from debian, but is switching OK?  Will Ubuntu 20.04.4 LTS cause any issues with any of the other images?  It seems to be working OK in the [milmove PR](https://github.com/transcom/mymove/pull/9956) I created.

[MB-15041]: https://dp3.atlassian.net/browse/MB-15041?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ