### PR TITLE
[MB-15155] adds a codeowners file with platform team review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Added platform team as code owners so that PRs do not get missed
-Dockerfile @transcom/truss-platform-team
+Dockerfile @transcom/truss-platform-team @transcom/truss-is3 @transcom/truss-sr-eng
 /milmove-atlantis @transcom/truss-platform-team
 # For tf, we maintain one old version plus the current
 /milmove-infra-tf112 @transcom/truss-platform-team

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# Added platform team as code owners so that PRs do not get missed
+Dockerfile @transcom/truss-platform-team
+/milmove-atlantis @transcom/truss-platform-team
+# For tf, we maintain one old version plus the current
+/milmove-infra-tf112 @transcom/truss-platform-team
+/milmove-infra-tf132 @transcom/truss-platform-team


### PR DESCRIPTION
# Description

The platform team historically tends to be slow to respond to pull requests on this repository since we don't have codeowners configured. I added us as codeowners for the base docker image and the 3 subdirectories for specifically platform related images