### PR TITLE
[MB-15297] Upgrade to go 1.20.1

### DIFF
--- a/milmove-app/Dockerfile
+++ b/milmove-app/Dockerfile
@@ -11,8 +11,8 @@ USER root
 ENV GOFLAGS=-p=4
 
 # install go
-ARG GO_VERSION=1.19.3
-ARG GO_SHA256SUM=74b9640724fd4e6bb0ed2a1bc44ae813a03f1e72a4c76253e2d5c015494430ba
+ARG GO_VERSION=1.20.1
+ARG GO_SHA256SUM=000a5b1fca4f75895f78befeb2eecf10bfff3c428597f3f1e69133b63b911b02
 RUN set -ex && cd ~ \
   && curl -sSLO https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz \
   && [ $(sha256sum go${GO_VERSION}.linux-amd64.tar.gz | cut -f1 -d' ') = ${GO_SHA256SUM} ] \


### PR DESCRIPTION
# Description

Update go from 1.19.3 to 1.20.1 in our docker images in anticipation of switching to Go 1.20.1 in milmove (see the [corresponding milmove PR](https://github.com/transcom/mymove/pull/10169)).  This new version incorporates some security fixes as well as opens the door for possible options related to FIPS 140-2 compliance.

To verify that go 1.20.1 is in the container, do the following:

```docker run --rm milmove/circleci-docker:milmove-app-b0321830e60511e17258e2d29abbc0dd8cf95d81 go version```

I generally followed [these upgrade instructions](https://transcom.github.io/mymove-docs/docs/backend/guides/how-to/upgrade-go-version).

## Changelog or Releases

Go 1.20.x version history:
https://go.dev/doc/devel/release#go1.20

Go 1.19.x version history:
https://go.dev/doc/devel/release#go1.19

## Reviewer Notes

I plan to test the milmove PR using this branch and only merge this PR once everything passes and seems OK.  I'll then update the new `main` hash in the milmove PR.
