### PR TITLE
[MB-15297] Revert "Bump cimg/python from 3.10.7-node to 3.11.2-node"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # CircleCI docker image to run within
-FROM cimg/python:3.11.2-node
+FROM cimg/python:3.10.7-node
 # Base image uses "circleci", to avoid using `sudo` run as root user
 USER root
 


### PR DESCRIPTION
Reverts transcom/circleci-docker#377

See this [Slack thread](https://ustcdp3.slack.com/archives/CP4U2NKRT/p1677774846308069?thread_ts=1677706828.317889&cid=CP4U2NKRT) for more context.

In a nutshell, we get consistent failures in a couple of app deployment steps when using a `milmove-app` image that uses this updated base image that was merged last week in #377.  It only became apparent once I updated the `milmove-app` image to a new go version and used that hash (which includes the new base image) in milmove.  Based on tests on experimental (see the Slack thread above), going back to the previous version seems to clear up the problem.

[Here's the PR](https://github.com/transcom/mymove/pull/10185) on the MilMove side that references the hash for this PR's commit.  Once this is merged, I'll use the resulting main hash instead.