### PR TITLE
[MB-15587] Upgrade to go 1.20.3

### DIFF
--- a/milmove-app/Dockerfile
+++ b/milmove-app/Dockerfile
@@ -11,8 +11,8 @@ USER root
 ENV GOFLAGS=-p=4
 
 # install go
-ARG GO_VERSION=1.20.1
-ARG GO_SHA256SUM=000a5b1fca4f75895f78befeb2eecf10bfff3c428597f3f1e69133b63b911b02
+ARG GO_VERSION=1.20.3
+ARG GO_SHA256SUM=979694c2c25c735755bf26f4f45e19e64e4811d661dd07b8c010f7a8e18adfca
 RUN set -ex && cd ~ \
   && curl -sSLO https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz \
   && [ $(sha256sum go${GO_VERSION}.linux-amd64.tar.gz | cut -f1 -d' ') = ${GO_SHA256SUM} ] \


### PR DESCRIPTION
# Description

Update go from 1.20.1 to 1.20.3 - Includes releases with security fixes.

[Followed this guide for upgrading](https://transcom.github.io/mymove-docs/docs/backend/guides/how-to/upgrade-go-version/)

[mymove update](https://github.com/transcom/mymove/pull/10450) that is currently in draft

## Changelog or Releases

- [golang](https://go.dev/doc/devel/release)
  - go1.20.2 (released 2023-03-07) includes a security fix to the crypto/elliptic package, as well as bug fixes to the compiler, the covdata command, the linker, the runtime, and the crypto/ecdh, crypto/rsa, crypto/x509, os, and syscall packages. See the [Go 1.20.2 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.20.2+label%3ACherryPickApproved) on our issue tracker for details.
  - go1.20.3 (released 2023-04-04) includes security fixes to the go/parser, html/template, mime/multipart, net/http, and net/textproto packages, as well as bug fixes to the compiler, the linker, the runtime, and the time package. See the [Go 1.20.3 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.20.3+label%3ACherryPickApproved) on our issue tracker for details.