### PR TITLE
Go upgrade - 1.23.0

### DIFF
--- a/milmove-app/Dockerfile
+++ b/milmove-app/Dockerfile
@@ -32,23 +32,25 @@ RUN set -ex && cd ~ \
 # apt-get project dependencies
 # Notes:
 # - When adding apt sources do it before 'apt-get update'
-ARG SETUP_18_X_SHA256SUM="86a3bed32e7505046b574238810a2978b1d50be740ad13f18dc674b6e46af9a5"
+ARG NODE_JS_VERSION="v18.20.4"
+# Pulled from https://nodejs.org/dist/v18.20.4/SHASUMS256.txt
+ARG NODE_JS_SHASUM256="c4b0827dc47609d0a8379e6de6c74b3934da0b1312c733b5ebdcac16e3f1e954"
 
 ARG CACHE_APT
 RUN set -ex && cd ~ \
   && : Remove existing node \
   && rm -rf /usr/local/bin/node /usr/local/bin/nodejs \
-  && : Add Node 18.20.2 \
-  && curl -sSLO https://deb.nodesource.com/setup_18.x \
-  && echo "${SETUP_18_X_SHA256SUM} setup_18.x" | sha256sum -c - \
-  && bash setup_18.x \
-  && rm setup_18.x \
+  && : Install LTS NodeJS v18.20.4 \
+  && curl -sSLO https://nodejs.org/dist/${NODE_JS_VERSION}/node-${NODE_JS_VERSION}-linux-x64.tar.gz \
+  && [ $(sha256sum node-${NODE_JS_VERSION}-linux-x64.tar.gz | cut -f1 -d' ') = ${NODE_JS_SHASUM256} ] \
+  && tar -C /usr/local -xzf node-${NODE_JS_VERSION}-linux-x64.tar.gz \
+  && rm -v node-${NODE_JS_VERSION}-linux-x64.tar.gz \
   && : Add Yarn \
   && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
   && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
   && apt-get -qq update \
   && : Install apt packages \
-  && apt-get -qq -y install --no-install-recommends nodejs yarn entr postgresql-client \
+  && apt-get -qq -y install --no-install-recommends yarn entr postgresql-client \
   && : Cleanup \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*

--- a/milmove-app/Dockerfile
+++ b/milmove-app/Dockerfile
@@ -45,6 +45,8 @@ RUN set -ex && cd ~ \
   && [ $(sha256sum node-${NODE_JS_VERSION}-linux-x64.tar.gz | cut -f1 -d' ') = ${NODE_JS_SHASUM256} ] \
   && tar -C /usr/local -xzf node-${NODE_JS_VERSION}-linux-x64.tar.gz \
   && rm -v node-${NODE_JS_VERSION}-linux-x64.tar.gz \
+  # Force symbolic link override
+  && ln -sf /usr/local/node-${NODE_JS_VERSION}-linux-x64/bin/* /usr/local/bin \
   && : Add Yarn \
   && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
   && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \

--- a/milmove-app/Dockerfile
+++ b/milmove-app/Dockerfile
@@ -11,8 +11,8 @@ USER root
 ENV GOFLAGS=-p=4
 
 # install go
-ARG GO_VERSION=1.22.2
-ARG GO_SHA256SUM=5901c52b7a78002aeff14a21f93e0f064f74ce1360fce51c6ee68cd471216a17
+ARG GO_VERSION=1.23.0
+ARG GO_SHA256SUM=905a297f19ead44780548933e0ff1a1b86e8327bb459e92f9c0012569f76f5e3
 RUN set -ex && cd ~ \
   && curl -sSLO https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz \
   && [ $(sha256sum go${GO_VERSION}.linux-amd64.tar.gz | cut -f1 -d' ') = ${GO_SHA256SUM} ] \


### PR DESCRIPTION
[B-20641](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-20641)

# Description

- Upgrade Go 1.22.2 to 1.23.0
- Switch from [nodesource](https://deb.nodesource.com/) binary distribution to self-installed [nodejs distribution package](https://nodejs.org/dist/)
  - This was done due to the nodesource script's sha256 no longer matching what we stored, with no release notes or tracking

Following instructions - here:
https://dp3.atlassian.net/wiki/spaces/MT/pages/1931673649/How+to+Upgrade+Go+Version

## Changelog or Releases

https://go.dev/doc/devel/release#go1.23.0
