### PR TITLE
bump to go 1.23.1

### DIFF
--- a/milmove-app/Dockerfile
+++ b/milmove-app/Dockerfile
@@ -11,8 +11,8 @@ USER root
 ENV GOFLAGS=-p=4
 
 # install go
-ARG GO_VERSION=1.23.0
-ARG GO_SHA256SUM=905a297f19ead44780548933e0ff1a1b86e8327bb459e92f9c0012569f76f5e3
+ARG GO_VERSION=1.23.1
+ARG GO_SHA256SUM=49bbb517cfa9eee677e1e7897f7cf9cfdbcf49e05f61984a2789136de359f9bd
 RUN set -ex && cd ~ \
   && curl -sSLO https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz \
   && [ $(sha256sum go${GO_VERSION}.linux-amd64.tar.gz | cut -f1 -d' ') = ${GO_SHA256SUM} ] \


### PR DESCRIPTION
[B-20641](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-20641)

# Description

While in the process of upgrading to go `1.23.0`, it has been archived due to a security finding and patched with `1.23.1`. See [patch note](https://go.dev/doc/devel/release#go1.23.minor).

## Changelog or Releases

- [golang](https://go.dev/doc/devel/release)
